### PR TITLE
Add API subdomain and IP allowlist for external access

### DIFF
--- a/infrastructure/.env.prod.example
+++ b/infrastructure/.env.prod.example
@@ -72,6 +72,10 @@ DOMAIN_NAME=mydomain.example
 # IMPORTANT: This email will receive certificate expiry warnings
 LETSENCRYPT_EMAIL=admin@mydomain.example
 
+# IP allowlist for external API access (api.${DOMAIN_NAME})
+# Auto-populated by deploy.sh from whatismyip.akamai.com
+ALLOWED_IP=
+
 # =============================================================================
 # LINODE VOLUME STORAGE
 # =============================================================================

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -42,12 +42,18 @@ services:
       LOG_LEVEL: info
     volumes:
       - ./secrets/api-service:/app/secrets:ro
-    ports:
-      - "${API_PORT}:${API_PORT}"
     depends_on:
       - postgres
     networks:
       - beef-prod-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api-service.rule=Host(`api.${DOMAIN_NAME}`)"
+      - "traefik.http.routers.api-service.entrypoints=websecure"
+      - "traefik.http.routers.api-service.tls.certresolver=letsencrypt"
+      - "traefik.http.services.api-service.loadbalancer.server.port=${API_PORT}"
+      - "traefik.http.middlewares.api-ipallow.ipallowlist.sourcerange=${ALLOWED_IP}"
+      - "traefik.http.routers.api-service.middlewares=api-ipallow"
     restart: unless-stopped
 
   telegram-bot:

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -143,6 +143,15 @@ resource "linode_domain_record" "beef_briefing_www_record" {
   ttl_sec     = 300
 }
 
+# API subdomain for external API access
+resource "linode_domain_record" "beef_briefing_api_record" {
+  domain_id   = linode_domain.beef_briefing_domain.id
+  name        = "api"
+  record_type = "A"
+  target      = tolist(linode_instance.beef_briefing.ipv4)[0]
+  ttl_sec     = 300
+}
+
 # PostgreSQL persistent data volume
 resource "linode_volume" "beef_briefing_postgres_volume" {
   label     = var.postgres_volume_label

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -74,6 +74,23 @@ log_success "SSH host: $SSH_HOST"
 COMMIT_HASH=$(get_commit_hash)
 log_success "Commit hash: $COMMIT_HASH"
 
+# Fetch deployer's IP for API allowlist
+log_info "Fetching current IP address..."
+ALLOWED_IP=$(curl -s whatismyip.akamai.com)
+if [[ -z "$ALLOWED_IP" ]]; then
+    log_error "Failed to fetch IP from whatismyip.akamai.com"
+    exit 1
+fi
+log_success "Current IP: $ALLOWED_IP"
+
+# Update ALLOWED_IP in .env.prod
+if grep -q "^ALLOWED_IP=" "$PROD_ENV_FILE"; then
+    sed -i "s/^ALLOWED_IP=.*/ALLOWED_IP=$ALLOWED_IP/" "$PROD_ENV_FILE"
+else
+    echo "ALLOWED_IP=$ALLOWED_IP" >> "$PROD_ENV_FILE"
+fi
+log_success "Updated ALLOWED_IP in .env.prod"
+
 # Detect remote server architecture for cross-platform builds
 log_info "Detecting remote server architecture..."
 REMOTE_ARCH=$(get_remote_arch "$SSH_HOST")


### PR DESCRIPTION
- Updated .env.prod.example to include ALLOWED_IP for API access.
- Modified docker-compose.prod.yml to configure Traefik for the API service.
- Added Terraform resource for API subdomain DNS record.
- Enhanced deploy.sh to fetch and update the deployer's IP in .env.prod.