### PR TITLE
ML dashboard in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,6 +479,43 @@ ml-clean-cards-prod: ## Clean cards for a chat (prod). Usage: make ml-clean-card
 	./scripts/ml-processor.sh --prod clean-cards $(ML_ARGS)
 
 # =============================================================================
+# ML DASHBOARD (ml-dashboard-*)
+# =============================================================================
+# Dev-only tool for exploring ML-processed data
+# Backend: FastAPI (port 8052) | Frontend: React/Vite (port 5175)
+
+ml-dashboard-up: ## Start ML Dashboard (backend + frontend)
+	@$(DC) up -d ml-dashboard-backend ml-dashboard-frontend
+	@echo ""
+	@echo "ML Dashboard started:"
+	@echo "  Frontend: http://localhost:5175"
+	@echo "  Backend:  http://localhost:8052"
+	@echo ""
+
+ml-dashboard-up-build: ## Rebuild and start ML Dashboard
+	@$(DC) up -d --build ml-dashboard-backend ml-dashboard-frontend
+	@echo ""
+	@echo "ML Dashboard started:"
+	@echo "  Frontend: http://localhost:5175"
+	@echo "  Backend:  http://localhost:8052"
+	@echo ""
+
+ml-dashboard-down: ## Stop ML Dashboard services
+	@$(DC) stop ml-dashboard-backend ml-dashboard-frontend
+
+ml-dashboard-logs: ## Tail logs from ML Dashboard services
+	$(DC) logs -f ml-dashboard-backend ml-dashboard-frontend
+
+ml-dashboard-logs-backend: ## Tail logs from ML Dashboard backend
+	$(DC) logs -f ml-dashboard-backend
+
+ml-dashboard-logs-frontend: ## Tail logs from ML Dashboard frontend
+	$(DC) logs -f ml-dashboard-frontend
+
+ml-dashboard-shell: ## Open shell in ML Dashboard backend container
+	$(DC) exec ml-dashboard-backend /bin/bash
+
+# =============================================================================
 # MINIO CLIENT (mc-*)
 # =============================================================================
 mc-setup-prod: ## Configure MinIO Client alias for production
@@ -518,4 +555,6 @@ mc-setup-prod: ## Configure MinIO Client alias for production
 	ml-run ml-run-status ml-run-once ml-run-continuous ml-run-cards ml-run-render \
 	ml-run-prod ml-run-status-prod ml-run-once-prod ml-run-continuous-prod ml-run-cards-prod ml-run-render-prod \
 	ml-shell ml-clean-dev ml-clean-prod ml-clean-cards-dev ml-clean-cards-prod \
+	ml-dashboard-up ml-dashboard-up-build ml-dashboard-down ml-dashboard-logs \
+	ml-dashboard-logs-backend ml-dashboard-logs-frontend ml-dashboard-shell \
 	mc-setup-prod

--- a/apps/ml-dashboard/README.md
+++ b/apps/ml-dashboard/README.md
@@ -1,0 +1,285 @@
+# ML Dashboard
+
+A dev-only web dashboard for exploring ML-processed data from the ml-processor service.
+
+## Overview
+
+The ML Dashboard provides a visual interface to browse and analyze the machine learning results stored in PostgreSQL and Qdrant. It's designed for development and debugging purposes, allowing you to:
+
+- Browse messages with their ML annotations (sentiment, toxicity, humor, questions)
+- Perform semantic similarity search using Qdrant embeddings
+- Explore topic clusters and their keywords
+- View user analytics with aggregated ML statistics
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    ML Dashboard                              │
+├─────────────────────────┬───────────────────────────────────┤
+│   Frontend (React)      │        Backend (FastAPI)          │
+│   Port: 5175            │        Port: 8052                 │
+│                         │                                   │
+│   - Dashboard           │   /api/stats      - Stats         │
+│   - Messages Browser    │   /api/messages   - ML results    │
+│   - Semantic Search     │   /api/search     - Qdrant search │
+│   - Topic Explorer      │   /api/topics     - Clusters      │
+│   - User Analytics      │   /api/users      - User stats    │
+└─────────────────────────┴───────────────────────────────────┘
+            │                           │
+            │                           ├──► PostgreSQL (ML tables)
+            │                           └──► Qdrant (embeddings)
+            │
+            └──► Backend API (localhost:8052)
+```
+
+## Quick Start
+
+```bash
+# Start the dashboard (builds images if needed)
+make ml-dashboard-up-build
+
+# Access the dashboard
+open http://localhost:5175
+
+# View logs
+make ml-dashboard-logs
+```
+
+## Features
+
+### 1. Dashboard
+- Processing progress (messages analyzed vs total)
+- ML result counts (sentiment, toxicity, humor, questions, entities, topics)
+- Qdrant connection status and embedding count
+
+### 2. Messages Browser
+- Paginated list of messages with ML annotations
+- Filter by:
+  - Sentiment (positive, neutral, negative)
+  - Toxicity (toxic / not toxic)
+  - Humor (humorous / not humorous)
+  - Questions (is question / not question)
+  - Topic cluster
+- Sort by date, toxicity score, or sentiment score
+- Click to expand message details with named entities
+
+### 3. Semantic Search
+- Text-to-vector search using the same embedding model as ml-processor
+- Find semantically similar messages across the chat
+- Shows similarity scores and timing metrics
+- **Note:** Only available when Qdrant is running (dev environment)
+
+### 4. Topic Explorer
+- Browse discovered topic clusters
+- View keywords extracted for each topic
+- Drill down into topic messages sorted by similarity
+- See outlier count (unclustered messages)
+
+### 5. User Analytics
+- User list with aggregated ML statistics:
+  - Average sentiment (-1 to +1)
+  - Toxicity rate (% of toxic messages)
+  - Humor rate (% of humorous messages)
+  - Question rate (% of questions)
+- User profile with sentiment distribution pie chart
+- Entity mention frequency
+- Card history with weekly stats
+
+## Database Access Modes
+
+### Development (Default)
+Connects to the local PostgreSQL container and Qdrant:
+- PostgreSQL: `postgres:5432` (docker container)
+- Qdrant: `qdrant:6333` (docker container)
+
+```bash
+make ml-dashboard-up
+```
+
+### Production Database (via SSH Tunnel)
+Connect to production PostgreSQL while keeping local Qdrant:
+
+```bash
+# Terminal 1: Open SSH tunnel
+make pg-tunnel
+
+# Terminal 2: Restart backend with prod connection
+docker compose -f infrastructure/docker-compose.dev.yml stop ml-dashboard-backend
+DB_HOST=host.docker.internal DB_PORT=5433 \
+  docker compose -f infrastructure/docker-compose.dev.yml up -d ml-dashboard-backend
+```
+
+**Note:** Semantic search won't work with production data since Qdrant only runs locally.
+
+## API Endpoints
+
+### Stats & Chats
+| Endpoint | Description |
+|----------|-------------|
+| `GET /health` | Health check |
+| `GET /api/chats` | List all chats with message counts |
+| `GET /api/stats?chat_id=X` | ML processing statistics |
+
+### Messages
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/messages?chat_id=X` | List messages with ML results |
+| `GET /api/messages/{id}` | Single message with entities |
+
+Query parameters for `/api/messages`:
+- `limit` (default: 50, max: 200)
+- `offset` (default: 0)
+- `user_id` - Filter by user
+- `sentiment` - `positive`, `neutral`, or `negative`
+- `is_toxic` - `true` or `false`
+- `is_humorous` - `true` or `false`
+- `is_question` - `true` or `false`
+- `topic_id` - Filter by topic cluster
+- `sort_by` - `date`, `toxicity_score`, or `sentiment_score`
+- `sort_order` - `asc` or `desc`
+
+### Search
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/search/status` | Qdrant availability status |
+| `POST /api/search` | Semantic similarity search |
+
+Search request body:
+```json
+{
+  "query": "search text",
+  "chat_id": 123,
+  "user_id": 456,
+  "limit": 20
+}
+```
+
+### Topics
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/topics?chat_id=X` | List topic clusters |
+| `GET /api/topics/{id}/messages?chat_id=X` | Messages in a topic |
+
+### Users
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/users?chat_id=X` | List users with ML stats |
+| `GET /api/users/{id}/profile?chat_id=X` | User sentiment & entities |
+| `GET /api/users/{id}/cards?chat_id=X` | User card history |
+
+## Configuration
+
+### Backend Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_HOST` | `postgres` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_USER` | `postgres` | Database user |
+| `DB_PASSWORD` | - | Database password |
+| `DB_NAME` | `beef_briefing` | Database name |
+| `QDRANT_HOST` | `qdrant` | Qdrant host |
+| `QDRANT_PORT` | `6333` | Qdrant port |
+| `QDRANT_ENABLED` | `true` | Enable Qdrant connection |
+| `LOG_LEVEL` | `debug` | Logging level |
+
+### Frontend Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VITE_API_URL` | `http://localhost:8052` | Backend API URL |
+
+## Development
+
+### Backend Structure
+```
+backend/
+├── main.py           # FastAPI app, lifespan, global instances
+├── config.py         # Pydantic settings
+├── api/
+│   ├── messages.py   # /api/messages endpoints
+│   ├── search.py     # /api/search endpoints
+│   ├── topics.py     # /api/topics endpoints
+│   └── users.py      # /api/users endpoints
+├── db/
+│   └── queries.py    # SQL queries (follows MLQueries pattern)
+└── vector/
+    ├── qdrant.py     # Qdrant search wrapper
+    └── embeddings.py # Sentence transformer for search
+```
+
+### Frontend Structure
+```
+frontend/
+├── src/
+│   ├── App.tsx           # Router, chat context
+│   ├── api/client.ts     # API client
+│   ├── types/index.ts    # TypeScript interfaces
+│   ├── styles/global.css # Dark theme
+│   └── pages/
+│       ├── DashboardPage.tsx
+│       ├── MessagesPage.tsx
+│       ├── SearchPage.tsx
+│       ├── TopicsPage.tsx
+│       └── UsersPage.tsx
+```
+
+### Running Locally (without Docker)
+
+**Backend:**
+```bash
+cd apps/ml-dashboard/backend
+pip install -r requirements.txt
+DB_HOST=localhost DB_PORT=5432 python main.py
+```
+
+**Frontend:**
+```bash
+cd apps/ml-dashboard/frontend
+npm install
+npm run dev
+```
+
+## Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make ml-dashboard-up` | Start dashboard services |
+| `make ml-dashboard-up-build` | Rebuild and start |
+| `make ml-dashboard-down` | Stop dashboard services |
+| `make ml-dashboard-logs` | Tail all logs |
+| `make ml-dashboard-logs-backend` | Tail backend logs |
+| `make ml-dashboard-logs-frontend` | Tail frontend logs |
+| `make ml-dashboard-shell` | Shell into backend container |
+
+## Troubleshooting
+
+### "Database not connected" error
+Make sure PostgreSQL is running:
+```bash
+make dev-up  # Start all dev services including postgres
+```
+
+### Semantic search unavailable
+Qdrant must be running and have embeddings:
+```bash
+# Check Qdrant status
+curl http://localhost:6333/collections/message_embeddings
+
+# If empty, run ml-processor to generate embeddings
+make ml-run ML_ARGS="--chat-id YOUR_CHAT_ID"
+```
+
+### No chats showing
+The database needs message data. Either:
+1. Run the telegram-bot to collect messages
+2. Import data using import-cli
+3. Restore a database backup
+
+### Frontend not loading
+Check if the backend is accessible:
+```bash
+curl http://localhost:8052/health
+# Should return: {"status":"healthy"}
+```

--- a/apps/ml-dashboard/backend/Dockerfile
+++ b/apps/ml-dashboard/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY apps/ml-dashboard/backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY apps/ml-dashboard/backend/ .
+
+# Run with uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8052", "--reload"]

--- a/apps/ml-dashboard/backend/api/__init__.py
+++ b/apps/ml-dashboard/backend/api/__init__.py
@@ -1,0 +1,8 @@
+"""API routers for ML Dashboard."""
+
+from .messages import router as messages_router
+from .search import router as search_router
+from .topics import router as topics_router
+from .users import router as users_router
+
+__all__ = ["messages_router", "search_router", "topics_router", "users_router"]

--- a/apps/ml-dashboard/backend/api/messages.py
+++ b/apps/ml-dashboard/backend/api/messages.py
@@ -1,0 +1,84 @@
+"""Messages API - Browse ML results."""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from db import DashboardQueries
+
+router = APIRouter(prefix="/api/messages", tags=["messages"])
+
+
+def get_queries() -> DashboardQueries:
+    """Dependency to get database queries instance."""
+    from main import queries
+    return queries
+
+
+@router.get("")
+def list_messages(
+    chat_id: int = Query(..., description="Chat ID to filter by"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user_id: Optional[int] = Query(None),
+    sentiment: Optional[str] = Query(None, pattern="^(positive|neutral|negative)$"),
+    is_toxic: Optional[bool] = Query(None),
+    is_humorous: Optional[bool] = Query(None),
+    is_question: Optional[bool] = Query(None),
+    topic_id: Optional[int] = Query(None),
+    sort_by: str = Query("date", pattern="^(date|toxicity_score|sentiment_score)$"),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$"),
+    queries: DashboardQueries = Depends(get_queries),
+):
+    """
+    List messages with ML results.
+
+    Supports filtering by:
+    - user_id: Filter by specific user
+    - sentiment: positive, neutral, or negative
+    - is_toxic: true/false
+    - is_humorous: true/false
+    - is_question: true/false
+    - topic_id: Filter by topic cluster
+    """
+    messages, total = queries.get_messages(
+        chat_id=chat_id,
+        limit=limit,
+        offset=offset,
+        user_id=user_id,
+        sentiment=sentiment,
+        is_toxic=is_toxic,
+        is_humorous=is_humorous,
+        is_question=is_question,
+        topic_id=topic_id,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+
+    return {
+        "messages": messages,
+        "total": total,
+        "page_info": {
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + len(messages) < total,
+        },
+    }
+
+
+@router.get("/{message_id}")
+def get_message(
+    message_id: int,
+    queries: DashboardQueries = Depends(get_queries),
+):
+    """Get a single message with all ML details including entities."""
+    message = queries.get_message_detail(message_id)
+    if not message:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    entities = queries.get_message_entities(message_id)
+
+    return {
+        "message": message,
+        "entities": entities,
+    }

--- a/apps/ml-dashboard/backend/api/search.py
+++ b/apps/ml-dashboard/backend/api/search.py
@@ -1,0 +1,100 @@
+"""Search API - Semantic search using Qdrant embeddings."""
+
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from db import DashboardQueries
+from vector import EmbeddingService, QdrantSearcher
+
+router = APIRouter(prefix="/api/search", tags=["search"])
+
+
+class SearchRequest(BaseModel):
+    """Search request body."""
+
+    query: str
+    chat_id: Optional[int] = None
+    user_id: Optional[int] = None
+    limit: int = 20
+
+
+def get_dependencies():
+    """Get all dependencies."""
+    from main import queries, qdrant, embeddings
+    return queries, qdrant, embeddings
+
+
+@router.get("/status")
+def search_status():
+    """Check if semantic search is available."""
+    from main import qdrant, embeddings
+
+    qdrant_info = qdrant.get_collection_info() if qdrant else {"available": False}
+    model_loaded = embeddings.is_loaded() if embeddings else False
+
+    return {
+        "qdrant": qdrant_info,
+        "embedding_model_loaded": model_loaded,
+        "search_available": qdrant_info.get("available", False),
+    }
+
+
+@router.post("")
+def search_messages(request: SearchRequest):
+    """
+    Semantic search for similar messages.
+
+    Converts the query text to an embedding and searches Qdrant
+    for similar messages.
+    """
+    from main import queries, qdrant, embeddings
+
+    if not qdrant or not qdrant.is_available():
+        raise HTTPException(
+            status_code=503,
+            detail="Semantic search unavailable. Qdrant not connected (dev environment only).",
+        )
+
+    # Generate embedding for query
+    start_time = time.time()
+    query_vector = embeddings.embed(request.query)
+    embedding_time = (time.time() - start_time) * 1000
+
+    # Search Qdrant
+    search_start = time.time()
+    results = qdrant.search(
+        query_vector=query_vector,
+        chat_id=request.chat_id,
+        user_id=request.user_id,
+        limit=request.limit,
+    )
+    search_time = (time.time() - search_start) * 1000
+
+    # Enrich results with full message data
+    message_ids = [r["message_id"] for r in results]
+    messages_map = {}
+    if message_ids:
+        messages = queries.get_messages_by_ids(message_ids)
+        messages_map = {m["id"]: m for m in messages}
+
+    enriched_results = []
+    for r in results:
+        msg = messages_map.get(r["message_id"])
+        enriched_results.append({
+            "message_id": r["message_id"],
+            "score": r["score"],
+            "text_preview": r["text_preview"],
+            "message": msg,
+        })
+
+    return {
+        "results": enriched_results,
+        "query": request.query,
+        "timing": {
+            "embedding_ms": round(embedding_time, 2),
+            "search_ms": round(search_time, 2),
+        },
+    }

--- a/apps/ml-dashboard/backend/api/topics.py
+++ b/apps/ml-dashboard/backend/api/topics.py
@@ -1,0 +1,61 @@
+"""Topics API - Explore topic clusters."""
+
+from fastapi import APIRouter, Depends, Query
+
+from db import DashboardQueries
+
+router = APIRouter(prefix="/api/topics", tags=["topics"])
+
+
+def get_queries() -> DashboardQueries:
+    """Dependency to get database queries instance."""
+    from main import queries
+    return queries
+
+
+@router.get("")
+def list_topics(
+    chat_id: int = Query(..., description="Chat ID"),
+    queries: DashboardQueries = Depends(get_queries),
+):
+    """
+    List all topics for a chat.
+
+    Returns topics with their keywords and message counts.
+    Also includes count of unclustered (outlier) messages.
+    """
+    topics = queries.get_topics(chat_id)
+    outlier_count = queries.get_outlier_count(chat_id)
+
+    return {
+        "topics": topics,
+        "total_topics": len(topics),
+        "outlier_count": outlier_count,
+    }
+
+
+@router.get("/{topic_id}/messages")
+def get_topic_messages(
+    topic_id: int,
+    chat_id: int = Query(..., description="Chat ID"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    queries: DashboardQueries = Depends(get_queries),
+):
+    """Get messages assigned to a specific topic."""
+    messages, total = queries.get_topic_messages(
+        chat_id=chat_id,
+        topic_id=topic_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    return {
+        "messages": messages,
+        "total": total,
+        "page_info": {
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + len(messages) < total,
+        },
+    }

--- a/apps/ml-dashboard/backend/api/users.py
+++ b/apps/ml-dashboard/backend/api/users.py
@@ -1,0 +1,106 @@
+"""Users API - User analytics and cards."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from db import DashboardQueries
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+def get_queries() -> DashboardQueries:
+    """Dependency to get database queries instance."""
+    from main import queries
+    return queries
+
+
+@router.get("")
+def list_users(
+    chat_id: int = Query(..., description="Chat ID"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    queries: DashboardQueries = Depends(get_queries),
+):
+    """
+    List users with aggregated ML statistics.
+
+    Returns users with:
+    - message_count: Total messages in chat
+    - avg_sentiment: Average sentiment score (-1 to 1)
+    - toxicity_rate: Percentage of toxic messages (0 to 1)
+    - humor_rate: Percentage of humorous messages (0 to 1)
+    - question_rate: Percentage of questions (0 to 1)
+    """
+    users, total = queries.get_users_with_ml_stats(
+        chat_id=chat_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    return {
+        "users": users,
+        "total": total,
+        "page_info": {
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + len(users) < total,
+        },
+    }
+
+
+@router.get("/{user_id}/profile")
+def get_user_profile(
+    user_id: int,
+    chat_id: int = Query(..., description="Chat ID"),
+    queries: DashboardQueries = Depends(get_queries),
+):
+    """
+    Get detailed ML profile for a user.
+
+    Returns:
+    - Basic user info
+    - Sentiment distribution (positive/neutral/negative counts)
+    - Top entity mentions
+    """
+    # Get user stats first to verify user exists in chat
+    users, _ = queries.get_users_with_ml_stats(chat_id=chat_id, limit=1, offset=0)
+
+    # Get sentiment distribution
+    sentiment_dist = queries.get_user_sentiment_distribution(chat_id, user_id)
+
+    # Get entity mentions
+    entity_mentions = queries.get_user_entity_mentions(chat_id, user_id, limit=20)
+
+    # Calculate percentages
+    total = sentiment_dist.get("total", 0) or 0
+    sentiment_pct = {}
+    if total > 0:
+        sentiment_pct = {
+            "positive": round((sentiment_dist.get("positive", 0) or 0) / total * 100, 1),
+            "neutral": round((sentiment_dist.get("neutral", 0) or 0) / total * 100, 1),
+            "negative": round((sentiment_dist.get("negative", 0) or 0) / total * 100, 1),
+        }
+
+    return {
+        "user_id": user_id,
+        "sentiment_distribution": {
+            "counts": sentiment_dist,
+            "percentages": sentiment_pct,
+        },
+        "entity_mentions": entity_mentions,
+    }
+
+
+@router.get("/{user_id}/cards")
+def get_user_cards(
+    user_id: int,
+    chat_id: int = Query(..., description="Chat ID"),
+    queries: DashboardQueries = Depends(get_queries),
+):
+    """Get card history for a user."""
+    cards = queries.get_user_cards(chat_id, user_id)
+
+    return {
+        "user_id": user_id,
+        "cards": cards,
+        "total": len(cards),
+    }

--- a/apps/ml-dashboard/backend/config.py
+++ b/apps/ml-dashboard/backend/config.py
@@ -1,0 +1,49 @@
+"""
+Configuration for ML Dashboard backend.
+Uses Pydantic for environment variable parsing.
+"""
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Configuration loaded from environment variables."""
+
+    # Database Configuration
+    db_host: str = "postgres"
+    db_port: int = 5432
+    db_user: str = "postgres"
+    db_password: str = ""
+    db_name: str = "beef_briefing"
+    db_ssl_mode: str = "disable"
+
+    # Qdrant Configuration (dev only)
+    qdrant_host: str = "qdrant"
+    qdrant_port: int = 6333
+    qdrant_enabled: bool = True
+
+    # Embedding model (same as ml-processor for consistency)
+    embedding_model: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
+
+    # Application Settings
+    environment: str = "development"
+    log_level: str = "debug"
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    def dsn(self) -> str:
+        """Return PostgreSQL connection string."""
+        return (
+            f"postgresql://{self.db_user}:{self.db_password}"
+            f"@{self.db_host}:{self.db_port}/{self.db_name}"
+            f"?sslmode={self.db_ssl_mode}"
+        )
+
+    def is_production(self) -> bool:
+        """Check if running in production environment."""
+        return self.environment.lower() == "production"
+
+
+settings = Settings()

--- a/apps/ml-dashboard/backend/db/__init__.py
+++ b/apps/ml-dashboard/backend/db/__init__.py
@@ -1,0 +1,5 @@
+"""Database module for ML Dashboard."""
+
+from .queries import DashboardQueries
+
+__all__ = ["DashboardQueries"]

--- a/apps/ml-dashboard/backend/db/queries.py
+++ b/apps/ml-dashboard/backend/db/queries.py
@@ -1,0 +1,384 @@
+"""
+Database query layer for ML Dashboard.
+
+Design Principles:
+1. Raw SQL with SQLAlchemy text() - no ORM
+2. Parameterized queries with named parameters (:param)
+3. Connection pooling via SQLAlchemy engine
+"""
+
+import logging
+from typing import Any, Optional
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+
+class DashboardQueries:
+    """Database operations for ML Dashboard."""
+
+    def __init__(self, engine: Engine):
+        self._engine = engine
+
+    def _execute_single(self, query: str, params: dict) -> dict | None:
+        """Execute query expecting 0 or 1 row, return dict or None."""
+        with self._engine.connect() as conn:
+            result = conn.execute(text(query), params)
+            row = result.mappings().fetchone()
+            return dict(row) if row else None
+
+    def _execute_many(self, query: str, params: dict) -> list[dict]:
+        """Execute query expecting multiple rows, return list of dicts."""
+        with self._engine.connect() as conn:
+            result = conn.execute(text(query), params)
+            return [dict(row) for row in result.mappings()]
+
+    # =========================================
+    # STATS
+    # =========================================
+
+    def get_processing_stats(self, chat_id: int) -> dict:
+        """Get ML processing statistics for a chat."""
+        query = """
+        SELECT
+            (SELECT COUNT(*) FROM messages WHERE chat_id = :chat_id AND (text IS NOT NULL OR caption IS NOT NULL)) as total_with_text,
+            (SELECT COUNT(DISTINCT message_id) FROM ml_processing_state WHERE chat_id = :chat_id) as processed,
+            (SELECT COUNT(*) FROM ml_sentiment WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id)) as sentiment_count,
+            (SELECT COUNT(*) FROM ml_toxicity WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id)) as toxicity_count,
+            (SELECT COUNT(*) FROM ml_toxicity WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id) AND is_toxic = true) as toxic_count,
+            (SELECT COUNT(*) FROM ml_humor WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id)) as humor_count,
+            (SELECT COUNT(*) FROM ml_humor WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id) AND is_humorous = true) as humorous_count,
+            (SELECT COUNT(*) FROM ml_questions WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id)) as questions_count,
+            (SELECT COUNT(*) FROM ml_questions WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id) AND is_question = true) as question_count,
+            (SELECT COUNT(*) FROM ml_ner WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id)) as entity_count,
+            (SELECT COUNT(DISTINCT topic_id) FROM ml_message_topics WHERE message_id IN (SELECT id FROM messages WHERE chat_id = :chat_id) AND topic_id >= 0) as topic_count
+        """
+        return self._execute_single(query, {"chat_id": chat_id}) or {}
+
+    def get_chats(self) -> list[dict]:
+        """Get all chats with message counts."""
+        query = """
+        SELECT c.id, c.title, c.type, c.username,
+               COUNT(m.id) as message_count,
+               (SELECT COUNT(DISTINCT ps.message_id) FROM ml_processing_state ps
+                JOIN messages m2 ON m2.id = ps.message_id WHERE m2.chat_id = c.id) as processed_count
+        FROM chats c
+        LEFT JOIN messages m ON m.chat_id = c.id
+        GROUP BY c.id
+        ORDER BY message_count DESC
+        """
+        return self._execute_many(query, {})
+
+    # =========================================
+    # MESSAGES
+    # =========================================
+
+    def get_messages(
+        self,
+        chat_id: int,
+        limit: int = 50,
+        offset: int = 0,
+        user_id: Optional[int] = None,
+        sentiment: Optional[str] = None,
+        is_toxic: Optional[bool] = None,
+        is_humorous: Optional[bool] = None,
+        is_question: Optional[bool] = None,
+        topic_id: Optional[int] = None,
+        sort_by: str = "date",
+        sort_order: str = "desc",
+    ) -> tuple[list[dict], int]:
+        """
+        Get messages with ML results.
+
+        Returns:
+            Tuple of (messages, total_count)
+        """
+        # Build WHERE clause dynamically
+        conditions = ["m.chat_id = :chat_id", "(m.text IS NOT NULL OR m.caption IS NOT NULL)"]
+        params: dict[str, Any] = {"chat_id": chat_id, "limit": limit, "offset": offset}
+
+        if user_id is not None:
+            conditions.append("m.user_id = :user_id")
+            params["user_id"] = user_id
+
+        if sentiment is not None:
+            conditions.append("s.label = :sentiment")
+            params["sentiment"] = sentiment
+
+        if is_toxic is not None:
+            conditions.append("t.is_toxic = :is_toxic")
+            params["is_toxic"] = is_toxic
+
+        if is_humorous is not None:
+            conditions.append("h.is_humorous = :is_humorous")
+            params["is_humorous"] = is_humorous
+
+        if is_question is not None:
+            conditions.append("q.is_question = :is_question")
+            params["is_question"] = is_question
+
+        if topic_id is not None:
+            conditions.append("mt.topic_id = :topic_id")
+            params["topic_id"] = topic_id
+
+        where_clause = " AND ".join(conditions)
+
+        # Map sort_by to actual column
+        sort_columns = {
+            "date": "m.date",
+            "toxicity_score": "t.score",
+            "sentiment_score": "s.confidence",
+        }
+        order_col = sort_columns.get(sort_by, "m.date")
+        order_dir = "DESC" if sort_order.lower() == "desc" else "ASC"
+
+        # Count query
+        count_query = f"""
+        SELECT COUNT(DISTINCT m.id)
+        FROM messages m
+        LEFT JOIN ml_sentiment s ON s.message_id = m.id
+        LEFT JOIN ml_toxicity t ON t.message_id = m.id
+        LEFT JOIN ml_humor h ON h.message_id = m.id
+        LEFT JOIN ml_questions q ON q.message_id = m.id
+        LEFT JOIN ml_message_topics mt ON mt.message_id = m.id
+        WHERE {where_clause}
+        """
+        count_result = self._execute_single(count_query, params)
+        total = count_result["count"] if count_result else 0
+
+        # Main query
+        query = f"""
+        SELECT
+            m.id, m.message_id, m.chat_id, m.user_id,
+            COALESCE(m.text, m.caption) as text,
+            m.date,
+            u.first_name, u.last_name, u.username,
+            s.label as sentiment_label,
+            s.score_positive, s.score_neutral, s.score_negative,
+            s.confidence as sentiment_confidence,
+            t.is_toxic, t.label as toxicity_label, t.score as toxicity_score,
+            h.is_humorous, h.humor_type, h.score as humor_score,
+            q.is_question, q.question_type, q.score as question_score,
+            mt.topic_id, mt.similarity as topic_similarity
+        FROM messages m
+        LEFT JOIN users u ON u.id = m.user_id
+        LEFT JOIN ml_sentiment s ON s.message_id = m.id
+        LEFT JOIN ml_toxicity t ON t.message_id = m.id
+        LEFT JOIN ml_humor h ON h.message_id = m.id
+        LEFT JOIN ml_questions q ON q.message_id = m.id
+        LEFT JOIN ml_message_topics mt ON mt.message_id = m.id
+        WHERE {where_clause}
+        ORDER BY {order_col} {order_dir} NULLS LAST
+        LIMIT :limit OFFSET :offset
+        """
+        messages = self._execute_many(query, params)
+        return messages, total
+
+    def get_message_detail(self, message_id: int) -> dict | None:
+        """Get a single message with all ML details."""
+        query = """
+        SELECT
+            m.id, m.message_id, m.chat_id, m.user_id,
+            COALESCE(m.text, m.caption) as text,
+            m.date,
+            u.first_name, u.last_name, u.username,
+            s.label as sentiment_label,
+            s.score_positive, s.score_neutral, s.score_negative,
+            s.confidence as sentiment_confidence,
+            t.is_toxic, t.label as toxicity_label, t.score as toxicity_score,
+            h.is_humorous, h.humor_type, h.score as humor_score,
+            q.is_question, q.question_type, q.score as question_score,
+            mt.topic_id, mt.similarity as topic_similarity
+        FROM messages m
+        LEFT JOIN users u ON u.id = m.user_id
+        LEFT JOIN ml_sentiment s ON s.message_id = m.id
+        LEFT JOIN ml_toxicity t ON t.message_id = m.id
+        LEFT JOIN ml_humor h ON h.message_id = m.id
+        LEFT JOIN ml_questions q ON q.message_id = m.id
+        LEFT JOIN ml_message_topics mt ON mt.message_id = m.id
+        WHERE m.id = :message_id
+        """
+        return self._execute_single(query, {"message_id": message_id})
+
+    def get_message_entities(self, message_id: int) -> list[dict]:
+        """Get named entities for a message."""
+        query = """
+        SELECT entity_type, entity_text, start_pos, end_pos, confidence
+        FROM ml_ner
+        WHERE message_id = :message_id
+        ORDER BY start_pos NULLS LAST
+        """
+        return self._execute_many(query, {"message_id": message_id})
+
+    # =========================================
+    # TOPICS
+    # =========================================
+
+    def get_topics(self, chat_id: int) -> list[dict]:
+        """Get all topics for a chat with message counts."""
+        query = """
+        SELECT
+            t.topic_id, t.keywords, t.message_count,
+            (SELECT COUNT(*) FROM ml_message_topics mt
+             JOIN messages m ON m.id = mt.message_id
+             WHERE m.chat_id = :chat_id AND mt.topic_id = t.topic_id) as actual_count
+        FROM ml_topics t
+        WHERE t.chat_id = :chat_id AND t.topic_id >= 0
+        ORDER BY t.message_count DESC
+        """
+        return self._execute_many(query, {"chat_id": chat_id})
+
+    def get_topic_messages(
+        self, chat_id: int, topic_id: int, limit: int = 50, offset: int = 0
+    ) -> tuple[list[dict], int]:
+        """Get messages for a specific topic."""
+        count_query = """
+        SELECT COUNT(*)
+        FROM ml_message_topics mt
+        JOIN messages m ON m.id = mt.message_id
+        WHERE m.chat_id = :chat_id AND mt.topic_id = :topic_id
+        """
+        count_result = self._execute_single(
+            count_query, {"chat_id": chat_id, "topic_id": topic_id}
+        )
+        total = count_result["count"] if count_result else 0
+
+        query = """
+        SELECT
+            m.id, m.message_id, m.chat_id, m.user_id,
+            COALESCE(m.text, m.caption) as text,
+            m.date,
+            u.first_name, u.last_name, u.username,
+            mt.similarity
+        FROM messages m
+        JOIN ml_message_topics mt ON mt.message_id = m.id
+        LEFT JOIN users u ON u.id = m.user_id
+        WHERE m.chat_id = :chat_id AND mt.topic_id = :topic_id
+        ORDER BY mt.similarity DESC
+        LIMIT :limit OFFSET :offset
+        """
+        messages = self._execute_many(
+            query, {"chat_id": chat_id, "topic_id": topic_id, "limit": limit, "offset": offset}
+        )
+        return messages, total
+
+    def get_outlier_count(self, chat_id: int) -> int:
+        """Get count of unclustered messages (topic_id = -1)."""
+        query = """
+        SELECT COUNT(*)
+        FROM ml_message_topics mt
+        JOIN messages m ON m.id = mt.message_id
+        WHERE m.chat_id = :chat_id AND mt.topic_id = -1
+        """
+        result = self._execute_single(query, {"chat_id": chat_id})
+        return result["count"] if result else 0
+
+    # =========================================
+    # USERS
+    # =========================================
+
+    def get_users_with_ml_stats(
+        self, chat_id: int, limit: int = 50, offset: int = 0
+    ) -> tuple[list[dict], int]:
+        """Get users with aggregated ML statistics."""
+        count_query = """
+        SELECT COUNT(DISTINCT m.user_id)
+        FROM messages m
+        WHERE m.chat_id = :chat_id AND m.user_id IS NOT NULL
+        """
+        count_result = self._execute_single(count_query, {"chat_id": chat_id})
+        total = count_result["count"] if count_result else 0
+
+        query = """
+        SELECT
+            u.id as user_id, u.first_name, u.last_name, u.username,
+            COUNT(m.id) as message_count,
+            AVG(CASE s.label
+                WHEN 'positive' THEN s.confidence
+                WHEN 'negative' THEN -s.confidence
+                ELSE 0
+            END) as avg_sentiment,
+            AVG(CASE WHEN t.is_toxic THEN 1.0 ELSE 0.0 END) as toxicity_rate,
+            AVG(CASE WHEN h.is_humorous THEN 1.0 ELSE 0.0 END) as humor_rate,
+            AVG(CASE WHEN q.is_question THEN 1.0 ELSE 0.0 END) as question_rate
+        FROM users u
+        JOIN messages m ON m.user_id = u.id
+        LEFT JOIN ml_sentiment s ON s.message_id = m.id
+        LEFT JOIN ml_toxicity t ON t.message_id = m.id
+        LEFT JOIN ml_humor h ON h.message_id = m.id
+        LEFT JOIN ml_questions q ON q.message_id = m.id
+        WHERE m.chat_id = :chat_id
+        GROUP BY u.id
+        ORDER BY message_count DESC
+        LIMIT :limit OFFSET :offset
+        """
+        users = self._execute_many(query, {"chat_id": chat_id, "limit": limit, "offset": offset})
+        return users, total
+
+    def get_user_sentiment_distribution(self, chat_id: int, user_id: int) -> dict:
+        """Get sentiment distribution for a user."""
+        query = """
+        SELECT
+            COUNT(*) as total,
+            SUM(CASE WHEN s.label = 'positive' THEN 1 ELSE 0 END) as positive,
+            SUM(CASE WHEN s.label = 'neutral' THEN 1 ELSE 0 END) as neutral,
+            SUM(CASE WHEN s.label = 'negative' THEN 1 ELSE 0 END) as negative
+        FROM messages m
+        JOIN ml_sentiment s ON s.message_id = m.id
+        WHERE m.chat_id = :chat_id AND m.user_id = :user_id
+        """
+        return self._execute_single(query, {"chat_id": chat_id, "user_id": user_id}) or {}
+
+    def get_user_entity_mentions(
+        self, chat_id: int, user_id: int, limit: int = 20
+    ) -> list[dict]:
+        """Get most frequent entity mentions by a user."""
+        query = """
+        SELECT n.entity_type, n.entity_text, COUNT(*) as count
+        FROM ml_ner n
+        JOIN messages m ON m.id = n.message_id
+        WHERE m.chat_id = :chat_id AND m.user_id = :user_id
+        GROUP BY n.entity_type, n.entity_text
+        ORDER BY count DESC
+        LIMIT :limit
+        """
+        return self._execute_many(query, {"chat_id": chat_id, "user_id": user_id, "limit": limit})
+
+    def get_user_cards(self, chat_id: int, user_id: int) -> list[dict]:
+        """Get user cards history."""
+        query = """
+        SELECT id, user_id, chat_id, week_start, week_end, stats, trends, image_url, created_at
+        FROM ml_user_cards
+        WHERE chat_id = :chat_id AND user_id = :user_id
+        ORDER BY week_end DESC
+        """
+        return self._execute_many(query, {"chat_id": chat_id, "user_id": user_id})
+
+    # =========================================
+    # SEARCH HELPERS
+    # =========================================
+
+    def get_messages_by_ids(self, message_ids: list[int]) -> list[dict]:
+        """Get messages by their database IDs."""
+        if not message_ids:
+            return []
+
+        query = """
+        SELECT
+            m.id, m.message_id, m.chat_id, m.user_id,
+            COALESCE(m.text, m.caption) as text,
+            m.date,
+            u.first_name, u.last_name, u.username,
+            s.label as sentiment_label, s.confidence as sentiment_confidence,
+            t.is_toxic, t.score as toxicity_score,
+            h.is_humorous, h.score as humor_score
+        FROM messages m
+        LEFT JOIN users u ON u.id = m.user_id
+        LEFT JOIN ml_sentiment s ON s.message_id = m.id
+        LEFT JOIN ml_toxicity t ON t.message_id = m.id
+        LEFT JOIN ml_humor h ON h.message_id = m.id
+        WHERE m.id = ANY(:message_ids)
+        """
+        return self._execute_many(query, {"message_ids": message_ids})

--- a/apps/ml-dashboard/backend/main.py
+++ b/apps/ml-dashboard/backend/main.py
@@ -1,0 +1,153 @@
+"""
+ML Dashboard Backend - FastAPI application for exploring ML-processed data.
+
+Dev-only tool for browsing ML results, semantic search, topics, and user analytics.
+"""
+
+import logging
+import sys
+from contextlib import asynccontextmanager
+from typing import Optional
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import create_engine, text
+
+from config import settings
+from db import DashboardQueries
+from vector import EmbeddingService, QdrantSearcher
+
+# Configure logging
+log_level = getattr(logging, settings.log_level.upper(), logging.INFO)
+logging.basicConfig(
+    level=log_level,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+# Suppress verbose logging from libraries
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("sentence_transformers").setLevel(logging.WARNING)
+logging.getLogger("qdrant_client").setLevel(logging.WARNING)
+
+# Global instances
+queries: Optional[DashboardQueries] = None
+qdrant: Optional[QdrantSearcher] = None
+embeddings: Optional[EmbeddingService] = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan - setup and teardown."""
+    global queries, qdrant, embeddings
+
+    # Setup database
+    logger.info(f"Connecting to database at {settings.db_host}:{settings.db_port}")
+    engine = create_engine(settings.dsn(), pool_pre_ping=True)
+
+    # Test database connection
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        logger.info("Database connection successful")
+    except Exception as e:
+        logger.error(f"Database connection failed: {e}")
+        raise
+
+    queries = DashboardQueries(engine)
+
+    # Setup Qdrant (optional - may not be available)
+    if settings.qdrant_enabled:
+        logger.info(f"Connecting to Qdrant at {settings.qdrant_host}:{settings.qdrant_port}")
+        qdrant = QdrantSearcher(host=settings.qdrant_host, port=settings.qdrant_port)
+        if qdrant.is_available():
+            info = qdrant.get_collection_info()
+            logger.info(f"Qdrant connected: {info['points_count']} embeddings")
+        else:
+            logger.warning("Qdrant not available - semantic search disabled")
+            qdrant = None
+    else:
+        logger.info("Qdrant disabled by configuration")
+
+    # Setup embedding service (lazy loaded)
+    embeddings = EmbeddingService(model_name=settings.embedding_model)
+    logger.info(f"Embedding service initialized (model: {settings.embedding_model})")
+
+    logger.info("ML Dashboard backend started")
+    yield
+
+    # Cleanup
+    logger.info("ML Dashboard backend shutting down")
+
+
+# Create FastAPI app
+app = FastAPI(
+    title="ML Dashboard",
+    description="Dev-only dashboard for exploring ML-processed Telegram data",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+# CORS middleware for frontend
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Dev-only, allow all origins
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Import and include routers
+from api import messages_router, search_router, topics_router, users_router
+
+app.include_router(messages_router)
+app.include_router(search_router)
+app.include_router(topics_router)
+app.include_router(users_router)
+
+
+@app.get("/health")
+def health():
+    """Health check endpoint."""
+    return {"status": "healthy"}
+
+
+@app.get("/api/stats")
+def stats(chat_id: int):
+    """Get ML processing statistics for a chat."""
+    if not queries:
+        return {"error": "Database not connected"}
+
+    processing_stats = queries.get_processing_stats(chat_id)
+
+    # Get Qdrant status
+    qdrant_status = {"available": False, "points_count": 0}
+    if qdrant:
+        qdrant_status = qdrant.get_collection_info()
+
+    return {
+        "processing": processing_stats,
+        "qdrant": qdrant_status,
+    }
+
+
+@app.get("/api/chats")
+def list_chats():
+    """Get list of all chats with message counts."""
+    if not queries:
+        return {"error": "Database not connected"}
+
+    chats = queries.get_chats()
+    return {"chats": chats}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=8052,
+        reload=True,
+    )

--- a/apps/ml-dashboard/backend/requirements.txt
+++ b/apps/ml-dashboard/backend/requirements.txt
@@ -1,0 +1,20 @@
+# Web framework
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+
+# Database
+sqlalchemy>=2.0.0
+psycopg2-binary>=2.9.0
+
+# Vector database
+qdrant-client>=1.12.0
+
+# Embeddings (for semantic search)
+sentence-transformers>=3.3.0
+torch>=2.5.0
+
+# Configuration
+pydantic-settings>=2.6.0
+
+# Utilities
+numpy>=1.26.0

--- a/apps/ml-dashboard/backend/vector/__init__.py
+++ b/apps/ml-dashboard/backend/vector/__init__.py
@@ -1,0 +1,6 @@
+"""Vector module for semantic search."""
+
+from .embeddings import EmbeddingService
+from .qdrant import QdrantSearcher
+
+__all__ = ["EmbeddingService", "QdrantSearcher"]

--- a/apps/ml-dashboard/backend/vector/embeddings.py
+++ b/apps/ml-dashboard/backend/vector/embeddings.py
@@ -1,0 +1,60 @@
+"""
+Embedding service for semantic search.
+Uses the same model as ml-processor for consistency.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingService:
+    """
+    Service for generating text embeddings.
+
+    Lazy-loads the model on first use to avoid slow startup.
+    """
+
+    def __init__(self, model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"):
+        self._model_name = model_name
+        self._model = None
+
+    @property
+    def model(self):
+        """Lazy-load the sentence transformer model."""
+        if self._model is None:
+            logger.info(f"Loading embedding model: {self._model_name}")
+            from sentence_transformers import SentenceTransformer
+
+            self._model = SentenceTransformer(self._model_name)
+            logger.info("Embedding model loaded")
+        return self._model
+
+    def embed(self, text: str) -> list[float]:
+        """
+        Generate embedding for a text string.
+
+        Args:
+            text: Input text to embed
+
+        Returns:
+            768-dimensional embedding vector
+        """
+        return self.model.encode(text).tolist()
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """
+        Generate embeddings for multiple texts.
+
+        Args:
+            texts: List of input texts
+
+        Returns:
+            List of 768-dimensional embedding vectors
+        """
+        return self.model.encode(texts).tolist()
+
+    def is_loaded(self) -> bool:
+        """Check if the model is already loaded."""
+        return self._model is not None

--- a/apps/ml-dashboard/backend/vector/qdrant.py
+++ b/apps/ml-dashboard/backend/vector/qdrant.py
@@ -1,0 +1,119 @@
+"""
+Qdrant vector database client for semantic search.
+Reuses the same collection as ml-processor.
+"""
+
+import logging
+from typing import Optional
+
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+from qdrant_client.http.exceptions import UnexpectedResponse
+
+logger = logging.getLogger(__name__)
+
+COLLECTION_NAME = "message_embeddings"
+
+
+class QdrantSearcher:
+    """Client for searching message embeddings in Qdrant."""
+
+    def __init__(self, host: str = "localhost", port: int = 6333):
+        self._host = host
+        self._port = port
+        self._client: Optional[QdrantClient] = None
+
+    @property
+    def client(self) -> QdrantClient:
+        """Lazy-load the Qdrant client."""
+        if self._client is None:
+            self._client = QdrantClient(host=self._host, port=self._port)
+        return self._client
+
+    def is_available(self) -> bool:
+        """Check if Qdrant is available and the collection exists."""
+        try:
+            self.client.get_collection(COLLECTION_NAME)
+            return True
+        except Exception as e:
+            logger.warning(f"Qdrant not available: {e}")
+            return False
+
+    def search(
+        self,
+        query_vector: list[float],
+        chat_id: Optional[int] = None,
+        user_id: Optional[int] = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        """
+        Search for similar messages.
+
+        Args:
+            query_vector: Query embedding vector
+            chat_id: Optional chat ID to filter by
+            user_id: Optional user ID to filter by
+            limit: Maximum number of results
+
+        Returns:
+            List of dicts with message_id, score, and payload
+        """
+        query_filter = None
+        conditions = []
+
+        if chat_id is not None:
+            conditions.append(
+                models.FieldCondition(
+                    key="chat_id",
+                    match=models.MatchValue(value=chat_id),
+                )
+            )
+
+        if user_id is not None:
+            conditions.append(
+                models.FieldCondition(
+                    key="user_id",
+                    match=models.MatchValue(value=user_id),
+                )
+            )
+
+        if conditions:
+            query_filter = models.Filter(must=conditions)
+
+        try:
+            results = self.client.search(
+                collection_name=COLLECTION_NAME,
+                query_vector=query_vector,
+                query_filter=query_filter,
+                limit=limit,
+            )
+
+            return [
+                {
+                    "message_id": r.id,
+                    "score": r.score,
+                    "chat_id": r.payload.get("chat_id"),
+                    "user_id": r.payload.get("user_id"),
+                    "text_preview": r.payload.get("text_preview"),
+                }
+                for r in results
+            ]
+        except Exception as e:
+            logger.error(f"Qdrant search error: {e}")
+            return []
+
+    def get_collection_info(self) -> dict:
+        """Get collection statistics."""
+        try:
+            info = self.client.get_collection(COLLECTION_NAME)
+            points_count = getattr(info, "points_count", None)
+            if points_count is None:
+                points_count = getattr(info, "vectors_count", 0)
+            return {
+                "available": True,
+                "points_count": points_count,
+                "status": info.status.value if hasattr(info.status, "value") else str(info.status),
+            }
+        except (UnexpectedResponse, Exception) as e:
+            logger.warning(f"Could not get Qdrant collection info: {e}")
+            return {"available": False, "points_count": 0, "status": "unavailable"}

--- a/apps/ml-dashboard/frontend/index.html
+++ b/apps/ml-dashboard/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ML Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/ml-dashboard/frontend/package.json
+++ b/apps/ml-dashboard/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ml-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@typescript-eslint/eslint-plugin": "^8.15.0",
+    "@typescript-eslint/parser": "^8.15.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "eslint": "^9.15.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-refresh": "^0.4.14",
+    "typescript": "^5.6.3",
+    "vite": "^6.0.1"
+  }
+}

--- a/apps/ml-dashboard/frontend/src/App.tsx
+++ b/apps/ml-dashboard/frontend/src/App.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect, createContext, useContext } from 'react'
+import { Routes, Route, NavLink, useLocation } from 'react-router-dom'
+import { api } from './api/client'
+import type { Chat } from './types'
+
+// Pages
+import DashboardPage from './pages/DashboardPage'
+import MessagesPage from './pages/MessagesPage'
+import SearchPage from './pages/SearchPage'
+import TopicsPage from './pages/TopicsPage'
+import UsersPage from './pages/UsersPage'
+
+// Chat context for sharing selected chat across pages
+interface ChatContextType {
+  chatId: number | null
+  setChatId: (id: number) => void
+  chats: Chat[]
+  currentChat: Chat | null
+}
+
+const ChatContext = createContext<ChatContextType>({
+  chatId: null,
+  setChatId: () => {},
+  chats: [],
+  currentChat: null,
+})
+
+export const useChat = () => useContext(ChatContext)
+
+function App() {
+  const [chats, setChats] = useState<Chat[]>([])
+  const [chatId, setChatId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const location = useLocation()
+
+  useEffect(() => {
+    async function loadChats() {
+      try {
+        const response = await api.getChats()
+        setChats(response.chats)
+        // Auto-select first chat
+        if (response.chats.length > 0 && !chatId) {
+          setChatId(response.chats[0].id)
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load chats')
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadChats()
+  }, [])
+
+  const currentChat = chats.find((c) => c.id === chatId) || null
+
+  if (loading) {
+    return (
+      <div className="app-layout">
+        <div className="loading">Loading...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="app-layout">
+        <div className="main-content">
+          <div className="error">
+            <strong>Error:</strong> {error}
+            <p style={{ marginTop: '8px', fontSize: '13px' }}>
+              Make sure the backend is running at {import.meta.env.VITE_API_URL || 'http://localhost:8052'}
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <ChatContext.Provider value={{ chatId, setChatId, chats, currentChat }}>
+      <div className="app-layout">
+        <aside className="sidebar">
+          <div className="sidebar-header">
+            <div className="sidebar-title">ML Dashboard</div>
+            <div className="sidebar-subtitle">Dev-only exploration tool</div>
+          </div>
+
+          <nav className="sidebar-nav">
+            <NavLink to="/" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>
+              <span className="nav-icon">&#x1F4CA;</span>
+              Dashboard
+            </NavLink>
+            <NavLink to="/messages" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>
+              <span className="nav-icon">&#x1F4AC;</span>
+              Messages
+            </NavLink>
+            <NavLink to="/search" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>
+              <span className="nav-icon">&#x1F50D;</span>
+              Search
+            </NavLink>
+            <NavLink to="/topics" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>
+              <span className="nav-icon">&#x1F3F7;</span>
+              Topics
+            </NavLink>
+            <NavLink to="/users" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>
+              <span className="nav-icon">&#x1F465;</span>
+              Users
+            </NavLink>
+          </nav>
+
+          <div className="sidebar-footer">
+            <select
+              className="chat-selector"
+              value={chatId || ''}
+              onChange={(e) => setChatId(Number(e.target.value))}
+            >
+              {chats.map((chat) => (
+                <option key={chat.id} value={chat.id}>
+                  {chat.title || `Chat ${chat.id}`}
+                </option>
+              ))}
+            </select>
+          </div>
+        </aside>
+
+        <main className="main-content">
+          <Routes>
+            <Route path="/" element={<DashboardPage />} />
+            <Route path="/messages" element={<MessagesPage />} />
+            <Route path="/search" element={<SearchPage />} />
+            <Route path="/topics" element={<TopicsPage />} />
+            <Route path="/users" element={<UsersPage />} />
+          </Routes>
+        </main>
+      </div>
+    </ChatContext.Provider>
+  )
+}
+
+export default App

--- a/apps/ml-dashboard/frontend/src/api/client.ts
+++ b/apps/ml-dashboard/frontend/src/api/client.ts
@@ -1,0 +1,148 @@
+/**
+ * API client for ML Dashboard.
+ * No authentication needed - dev-only tool.
+ */
+
+import type {
+  ChatsResponse,
+  StatsResponse,
+  MessagesResponse,
+  MessageDetail,
+  TopicsResponse,
+  UsersResponse,
+  UserProfile,
+  UserCardsResponse,
+  SearchResponse,
+  SearchStatus,
+  MessageFilters,
+  Message,
+} from '../types'
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8052'
+
+class ApiClient {
+  private async fetch<T>(url: string, options?: RequestInit): Promise<T> {
+    const response = await fetch(`${API_BASE_URL}${url}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...options?.headers,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Request failed' }))
+      throw new Error(error.detail || `HTTP ${response.status}`)
+    }
+
+    return response.json()
+  }
+
+  // Health & Stats
+  async health(): Promise<{ status: string }> {
+    return this.fetch('/health')
+  }
+
+  async getChats(): Promise<ChatsResponse> {
+    return this.fetch('/api/chats')
+  }
+
+  async getStats(chatId: number): Promise<StatsResponse> {
+    return this.fetch(`/api/stats?chat_id=${chatId}`)
+  }
+
+  // Messages
+  async getMessages(
+    chatId: number,
+    limit: number = 50,
+    offset: number = 0,
+    filters?: MessageFilters
+  ): Promise<MessagesResponse> {
+    const params = new URLSearchParams({
+      chat_id: chatId.toString(),
+      limit: limit.toString(),
+      offset: offset.toString(),
+    })
+
+    if (filters?.user_id) params.set('user_id', filters.user_id.toString())
+    if (filters?.sentiment) params.set('sentiment', filters.sentiment)
+    if (filters?.is_toxic !== undefined) params.set('is_toxic', filters.is_toxic.toString())
+    if (filters?.is_humorous !== undefined) params.set('is_humorous', filters.is_humorous.toString())
+    if (filters?.is_question !== undefined) params.set('is_question', filters.is_question.toString())
+    if (filters?.topic_id) params.set('topic_id', filters.topic_id.toString())
+    if (filters?.sort_by) params.set('sort_by', filters.sort_by)
+    if (filters?.sort_order) params.set('sort_order', filters.sort_order)
+
+    return this.fetch(`/api/messages?${params}`)
+  }
+
+  async getMessage(messageId: number): Promise<MessageDetail> {
+    return this.fetch(`/api/messages/${messageId}`)
+  }
+
+  // Search
+  async getSearchStatus(): Promise<SearchStatus> {
+    return this.fetch('/api/search/status')
+  }
+
+  async search(
+    query: string,
+    chatId?: number,
+    userId?: number,
+    limit: number = 20
+  ): Promise<SearchResponse> {
+    return this.fetch('/api/search', {
+      method: 'POST',
+      body: JSON.stringify({
+        query,
+        chat_id: chatId,
+        user_id: userId,
+        limit,
+      }),
+    })
+  }
+
+  // Topics
+  async getTopics(chatId: number): Promise<TopicsResponse> {
+    return this.fetch(`/api/topics?chat_id=${chatId}`)
+  }
+
+  async getTopicMessages(
+    chatId: number,
+    topicId: number,
+    limit: number = 50,
+    offset: number = 0
+  ): Promise<MessagesResponse> {
+    const params = new URLSearchParams({
+      chat_id: chatId.toString(),
+      limit: limit.toString(),
+      offset: offset.toString(),
+    })
+    return this.fetch(`/api/topics/${topicId}/messages?${params}`)
+  }
+
+  // Users
+  async getUsers(
+    chatId: number,
+    limit: number = 50,
+    offset: number = 0
+  ): Promise<UsersResponse> {
+    const params = new URLSearchParams({
+      chat_id: chatId.toString(),
+      limit: limit.toString(),
+      offset: offset.toString(),
+    })
+    return this.fetch(`/api/users?${params}`)
+  }
+
+  async getUserProfile(chatId: number, userId: number): Promise<UserProfile> {
+    return this.fetch(`/api/users/${userId}/profile?chat_id=${chatId}`)
+  }
+
+  async getUserCards(chatId: number, userId: number): Promise<UserCardsResponse> {
+    return this.fetch(`/api/users/${userId}/cards?chat_id=${chatId}`)
+  }
+}
+
+// Singleton instance
+export const api = new ApiClient()

--- a/apps/ml-dashboard/frontend/src/main.tsx
+++ b/apps/ml-dashboard/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './styles/global.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/apps/ml-dashboard/frontend/src/pages/DashboardPage.tsx
+++ b/apps/ml-dashboard/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,181 @@
+import { useState, useEffect } from 'react'
+import { useChat } from '../App'
+import { api } from '../api/client'
+import type { StatsResponse } from '../types'
+
+export default function DashboardPage() {
+  const { chatId, currentChat } = useChat()
+  const [stats, setStats] = useState<StatsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function loadStats() {
+      if (!chatId) return
+      setLoading(true)
+      setError(null)
+      try {
+        const data = await api.getStats(chatId)
+        setStats(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load stats')
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadStats()
+  }, [chatId])
+
+  if (!chatId) {
+    return <div className="loading">Select a chat to view stats</div>
+  }
+
+  if (loading) {
+    return <div className="loading">Loading stats...</div>
+  }
+
+  if (error) {
+    return <div className="error">{error}</div>
+  }
+
+  if (!stats) {
+    return <div className="loading">No stats available</div>
+  }
+
+  const { processing, qdrant } = stats
+  const processedPct = processing.total_with_text > 0
+    ? Math.round((processing.processed / processing.total_with_text) * 100)
+    : 0
+
+  return (
+    <div>
+      <header className="page-header">
+        <h1 className="page-title">Dashboard</h1>
+        <p className="page-subtitle">
+          {currentChat?.title || `Chat ${chatId}`} - ML Processing Overview
+        </p>
+      </header>
+
+      {/* Processing Status */}
+      <section style={{ marginBottom: 'var(--spacing-xl)' }}>
+        <h2 style={{ fontSize: '16px', fontWeight: 600, marginBottom: 'var(--spacing-md)', color: 'var(--text-secondary)' }}>
+          Processing Status
+        </h2>
+        <div className="card" style={{ marginBottom: 'var(--spacing-md)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-sm)' }}>
+            <span style={{ fontSize: '14px', color: 'var(--text-secondary)' }}>
+              {processing.processed.toLocaleString()} / {processing.total_with_text.toLocaleString()} messages processed
+            </span>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: '14px', color: 'var(--accent-green)' }}>
+              {processedPct}%
+            </span>
+          </div>
+          <div className="progress-bar">
+            <div className="progress-fill" style={{ width: `${processedPct}%` }} />
+          </div>
+        </div>
+
+        <div className="stats-grid">
+          <div className="card">
+            <div className="card-title">Total Messages</div>
+            <div className="card-value">{processing.total_with_text.toLocaleString()}</div>
+            <div className="card-label">with text content</div>
+          </div>
+          <div className="card">
+            <div className="card-title">Processed</div>
+            <div className="card-value">{processing.processed.toLocaleString()}</div>
+            <div className="card-label">ML analyzed</div>
+          </div>
+        </div>
+      </section>
+
+      {/* ML Results */}
+      <section style={{ marginBottom: 'var(--spacing-xl)' }}>
+        <h2 style={{ fontSize: '16px', fontWeight: 600, marginBottom: 'var(--spacing-md)', color: 'var(--text-secondary)' }}>
+          ML Analysis Results
+        </h2>
+        <div className="stats-grid">
+          <div className="card">
+            <div className="card-title">Sentiment Analysis</div>
+            <div className="card-value">{processing.sentiment_count.toLocaleString()}</div>
+            <div className="card-label">messages analyzed</div>
+          </div>
+          <div className="card">
+            <div className="card-title">Toxicity Detection</div>
+            <div className="card-value" style={{ color: 'var(--accent-red)' }}>
+              {processing.toxic_count.toLocaleString()}
+            </div>
+            <div className="card-label">
+              toxic messages ({processing.toxicity_count > 0
+                ? ((processing.toxic_count / processing.toxicity_count) * 100).toFixed(1)
+                : 0}%)
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-title">Humor Detection</div>
+            <div className="card-value" style={{ color: 'var(--accent-purple)' }}>
+              {processing.humorous_count.toLocaleString()}
+            </div>
+            <div className="card-label">
+              humorous messages ({processing.humor_count > 0
+                ? ((processing.humorous_count / processing.humor_count) * 100).toFixed(1)
+                : 0}%)
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-title">Question Detection</div>
+            <div className="card-value" style={{ color: 'var(--accent-blue)' }}>
+              {processing.question_count.toLocaleString()}
+            </div>
+            <div className="card-label">
+              questions ({processing.questions_count > 0
+                ? ((processing.question_count / processing.questions_count) * 100).toFixed(1)
+                : 0}%)
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-title">Named Entities</div>
+            <div className="card-value" style={{ color: 'var(--accent-cyan)' }}>
+              {processing.entity_count.toLocaleString()}
+            </div>
+            <div className="card-label">entities extracted</div>
+          </div>
+          <div className="card">
+            <div className="card-title">Topic Clusters</div>
+            <div className="card-value">{processing.topic_count.toLocaleString()}</div>
+            <div className="card-label">distinct topics</div>
+          </div>
+        </div>
+      </section>
+
+      {/* Qdrant Status */}
+      <section>
+        <h2 style={{ fontSize: '16px', fontWeight: 600, marginBottom: 'var(--spacing-md)', color: 'var(--text-secondary)' }}>
+          Vector Database (Qdrant)
+        </h2>
+        <div className="card">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-md)' }}>
+            <div
+              style={{
+                width: 12,
+                height: 12,
+                borderRadius: '50%',
+                backgroundColor: qdrant.available ? 'var(--accent-green)' : 'var(--accent-red)',
+              }}
+            />
+            <div>
+              <div style={{ fontWeight: 500 }}>
+                {qdrant.available ? 'Connected' : 'Not Available'}
+              </div>
+              <div style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
+                {qdrant.available
+                  ? `${qdrant.points_count.toLocaleString()} embeddings stored`
+                  : 'Semantic search disabled'}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/ml-dashboard/frontend/src/pages/MessagesPage.tsx
+++ b/apps/ml-dashboard/frontend/src/pages/MessagesPage.tsx
@@ -1,0 +1,304 @@
+import { useState, useEffect } from 'react'
+import { useChat } from '../App'
+import { api } from '../api/client'
+import type { Message, MessageFilters, MessagesResponse } from '../types'
+
+function SentimentBadge({ label }: { label: string | null }) {
+  if (!label) return null
+  const className = `badge badge-${label}`
+  return <span className={className}>{label}</span>
+}
+
+function MessageCard({ message, onClick }: { message: Message; onClick: () => void }) {
+  const userName = message.first_name
+    ? `${message.first_name}${message.last_name ? ' ' + message.last_name : ''}`
+    : message.username || 'Unknown'
+
+  return (
+    <div className="message-card" onClick={onClick}>
+      <div className="message-header">
+        <div className="message-user">{userName}</div>
+        <div className="message-date">
+          {new Date(message.date).toLocaleString()}
+        </div>
+      </div>
+      <div className="message-text">
+        {message.text.length > 300 ? message.text.slice(0, 300) + '...' : message.text}
+      </div>
+      <div className="message-badges">
+        <SentimentBadge label={message.sentiment_label} />
+        {message.is_toxic && <span className="badge badge-toxic">Toxic</span>}
+        {message.is_humorous && <span className="badge badge-humor">Humor</span>}
+        {message.is_question && <span className="badge badge-question">Question</span>}
+        {message.topic_id !== null && message.topic_id >= 0 && (
+          <span className="badge badge-entity">Topic {message.topic_id}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function MessageDetail({ messageId, onClose }: { messageId: number; onClose: () => void }) {
+  const [data, setData] = useState<{ message: Message; entities: Array<{ entity_type: string; entity_text: string; confidence: number | null }> } | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getMessage(messageId).then(setData).finally(() => setLoading(false))
+  }, [messageId])
+
+  if (loading) return <div className="loading">Loading...</div>
+  if (!data) return null
+
+  const { message, entities } = data
+  const userName = message.first_name
+    ? `${message.first_name}${message.last_name ? ' ' + message.last_name : ''}`
+    : message.username || 'Unknown'
+
+  return (
+    <div className="card" style={{ marginBottom: 'var(--spacing-lg)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 'var(--spacing-md)' }}>
+        <div>
+          <div style={{ fontWeight: 600, fontSize: '16px' }}>{userName}</div>
+          <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+            {new Date(message.date).toLocaleString()} | ID: {message.id}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'var(--text-muted)',
+            fontSize: '20px',
+            cursor: 'pointer',
+          }}
+        >
+          &times;
+        </button>
+      </div>
+
+      <div style={{ marginBottom: 'var(--spacing-md)', lineHeight: 1.6 }}>
+        {message.text}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--spacing-md)', marginBottom: 'var(--spacing-md)' }}>
+        {message.sentiment_label && (
+          <div>
+            <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>SENTIMENT</div>
+            <SentimentBadge label={message.sentiment_label} />
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', marginTop: '4px', color: 'var(--text-secondary)' }}>
+              +{(message.score_positive! * 100).toFixed(0)}% |
+              ~{(message.score_neutral! * 100).toFixed(0)}% |
+              -{(message.score_negative! * 100).toFixed(0)}%
+            </div>
+          </div>
+        )}
+        {message.is_toxic !== null && (
+          <div>
+            <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>TOXICITY</div>
+            {message.is_toxic ? (
+              <span className="badge badge-toxic">Toxic ({(message.toxicity_score! * 100).toFixed(0)}%)</span>
+            ) : (
+              <span style={{ color: 'var(--text-secondary)' }}>Not toxic</span>
+            )}
+          </div>
+        )}
+        {message.is_humorous !== null && (
+          <div>
+            <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>HUMOR</div>
+            {message.is_humorous ? (
+              <span className="badge badge-humor">{message.humor_type} ({(message.humor_score! * 100).toFixed(0)}%)</span>
+            ) : (
+              <span style={{ color: 'var(--text-secondary)' }}>Not humorous</span>
+            )}
+          </div>
+        )}
+        {message.is_question !== null && (
+          <div>
+            <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>QUESTION</div>
+            {message.is_question ? (
+              <span className="badge badge-question">{message.question_type}</span>
+            ) : (
+              <span style={{ color: 'var(--text-secondary)' }}>Not a question</span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {entities.length > 0 && (
+        <div>
+          <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px' }}>ENTITIES</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+            {entities.map((e, i) => (
+              <span key={i} className="badge badge-entity">
+                {e.entity_type}: {e.entity_text}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function MessagesPage() {
+  const { chatId } = useChat()
+  const [messages, setMessages] = useState<Message[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [filters, setFilters] = useState<MessageFilters>({
+    sort_by: 'date',
+    sort_order: 'desc',
+  })
+
+  const limit = 50
+
+  useEffect(() => {
+    if (!chatId) return
+    setLoading(true)
+    api
+      .getMessages(chatId, limit, offset, filters)
+      .then((res) => {
+        setMessages(res.messages)
+        setTotal(res.total)
+      })
+      .finally(() => setLoading(false))
+  }, [chatId, offset, filters])
+
+  const handleFilterChange = (key: keyof MessageFilters, value: string | boolean | undefined) => {
+    setOffset(0)
+    setFilters((prev) => ({
+      ...prev,
+      [key]: value === '' ? undefined : value,
+    }))
+  }
+
+  if (!chatId) {
+    return <div className="loading">Select a chat to view messages</div>
+  }
+
+  return (
+    <div>
+      <header className="page-header">
+        <h1 className="page-title">Messages</h1>
+        <p className="page-subtitle">Browse messages with ML analysis results</p>
+      </header>
+
+      {/* Filters */}
+      <div className="filters-bar">
+        <div className="filter-group">
+          <label className="filter-label">Sentiment</label>
+          <select
+            className="filter-select"
+            value={filters.sentiment || ''}
+            onChange={(e) => handleFilterChange('sentiment', e.target.value as 'positive' | 'neutral' | 'negative' | undefined)}
+          >
+            <option value="">All</option>
+            <option value="positive">Positive</option>
+            <option value="neutral">Neutral</option>
+            <option value="negative">Negative</option>
+          </select>
+        </div>
+        <div className="filter-group">
+          <label className="filter-label">Toxic</label>
+          <select
+            className="filter-select"
+            value={filters.is_toxic === undefined ? '' : filters.is_toxic.toString()}
+            onChange={(e) => handleFilterChange('is_toxic', e.target.value === '' ? undefined : e.target.value === 'true')}
+          >
+            <option value="">All</option>
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </select>
+        </div>
+        <div className="filter-group">
+          <label className="filter-label">Humorous</label>
+          <select
+            className="filter-select"
+            value={filters.is_humorous === undefined ? '' : filters.is_humorous.toString()}
+            onChange={(e) => handleFilterChange('is_humorous', e.target.value === '' ? undefined : e.target.value === 'true')}
+          >
+            <option value="">All</option>
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </select>
+        </div>
+        <div className="filter-group">
+          <label className="filter-label">Question</label>
+          <select
+            className="filter-select"
+            value={filters.is_question === undefined ? '' : filters.is_question.toString()}
+            onChange={(e) => handleFilterChange('is_question', e.target.value === '' ? undefined : e.target.value === 'true')}
+          >
+            <option value="">All</option>
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </select>
+        </div>
+        <div className="filter-group">
+          <label className="filter-label">Sort By</label>
+          <select
+            className="filter-select"
+            value={filters.sort_by || 'date'}
+            onChange={(e) => handleFilterChange('sort_by', e.target.value as 'date' | 'toxicity_score' | 'sentiment_score')}
+          >
+            <option value="date">Date</option>
+            <option value="toxicity_score">Toxicity</option>
+            <option value="sentiment_score">Sentiment</option>
+          </select>
+        </div>
+        <div className="filter-group">
+          <label className="filter-label">Order</label>
+          <select
+            className="filter-select"
+            value={filters.sort_order || 'desc'}
+            onChange={(e) => handleFilterChange('sort_order', e.target.value as 'asc' | 'desc')}
+          >
+            <option value="desc">Newest</option>
+            <option value="asc">Oldest</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Selected message detail */}
+      {selectedId && (
+        <MessageDetail messageId={selectedId} onClose={() => setSelectedId(null)} />
+      )}
+
+      {/* Messages list */}
+      {loading ? (
+        <div className="loading">Loading messages...</div>
+      ) : (
+        <>
+          <div style={{ marginBottom: 'var(--spacing-md)', color: 'var(--text-secondary)', fontSize: '13px' }}>
+            Showing {offset + 1}-{Math.min(offset + messages.length, total)} of {total.toLocaleString()} messages
+          </div>
+          {messages.map((msg) => (
+            <MessageCard key={msg.id} message={msg} onClick={() => setSelectedId(msg.id)} />
+          ))}
+          <div className="pagination">
+            <button
+              className="pagination-btn"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - limit))}
+            >
+              Previous
+            </button>
+            <span className="pagination-info">
+              Page {Math.floor(offset / limit) + 1} of {Math.ceil(total / limit)}
+            </span>
+            <button
+              className="pagination-btn"
+              disabled={offset + limit >= total}
+              onClick={() => setOffset(offset + limit)}
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/ml-dashboard/frontend/src/pages/SearchPage.tsx
+++ b/apps/ml-dashboard/frontend/src/pages/SearchPage.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect } from 'react'
+import { useChat } from '../App'
+import { api } from '../api/client'
+import type { SearchResult, SearchStatus } from '../types'
+
+export default function SearchPage() {
+  const { chatId } = useChat()
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [status, setStatus] = useState<SearchStatus | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [timing, setTiming] = useState<{ embedding_ms: number; search_ms: number } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load search status on mount
+  useEffect(() => {
+    api.getSearchStatus().then(setStatus).catch(() => {
+      setStatus({ qdrant: { available: false, points_count: 0, status: 'unavailable' }, embedding_model_loaded: false, search_available: false })
+    })
+  }, [])
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!query.trim() || !chatId) return
+
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await api.search(query, chatId, undefined, 20)
+      setResults(response.results)
+      setTiming(response.timing)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Search failed')
+      setResults([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!chatId) {
+    return <div className="loading">Select a chat to search</div>
+  }
+
+  const searchAvailable = status?.search_available ?? false
+
+  return (
+    <div>
+      <header className="page-header">
+        <h1 className="page-title">Semantic Search</h1>
+        <p className="page-subtitle">Find similar messages using vector embeddings</p>
+      </header>
+
+      {/* Status indicator */}
+      {status && (
+        <div className="card" style={{ marginBottom: 'var(--spacing-lg)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-md)' }}>
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: '50%',
+                backgroundColor: searchAvailable ? 'var(--accent-green)' : 'var(--accent-red)',
+              }}
+            />
+            <div>
+              {searchAvailable ? (
+                <>
+                  <span style={{ fontWeight: 500 }}>Qdrant Connected</span>
+                  <span style={{ color: 'var(--text-muted)', marginLeft: 8 }}>
+                    {status.qdrant.points_count.toLocaleString()} embeddings
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span style={{ fontWeight: 500, color: 'var(--accent-orange)' }}>
+                    Semantic search unavailable
+                  </span>
+                  <span style={{ color: 'var(--text-muted)', marginLeft: 8 }}>
+                    Qdrant is only available in dev environment
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Search form */}
+      <form onSubmit={handleSearch} className="search-container">
+        <span className="search-icon">&#x1F50D;</span>
+        <input
+          type="text"
+          className="search-input"
+          placeholder={searchAvailable ? 'Search for similar messages...' : 'Search unavailable'}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          disabled={!searchAvailable || loading}
+        />
+      </form>
+
+      {error && <div className="error" style={{ marginBottom: 'var(--spacing-lg)' }}>{error}</div>}
+
+      {/* Results */}
+      {loading ? (
+        <div className="loading">Searching...</div>
+      ) : results.length > 0 ? (
+        <>
+          <div style={{ marginBottom: 'var(--spacing-md)', color: 'var(--text-secondary)', fontSize: '13px' }}>
+            Found {results.length} similar messages
+            {timing && (
+              <span style={{ color: 'var(--text-muted)', marginLeft: 8 }}>
+                (embedding: {timing.embedding_ms.toFixed(0)}ms, search: {timing.search_ms.toFixed(0)}ms)
+              </span>
+            )}
+          </div>
+          {results.map((result, i) => (
+            <div key={result.message_id} className="message-card" style={{ cursor: 'default' }}>
+              <div className="message-header">
+                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-sm)' }}>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: '12px',
+                      color: 'var(--accent-purple)',
+                      backgroundColor: 'rgba(163, 113, 247, 0.1)',
+                      padding: '2px 6px',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    #{i + 1}
+                  </span>
+                  <span className="message-user">
+                    {result.message?.first_name || 'Unknown'}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-sm)' }}>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: '12px',
+                      color: 'var(--accent-green)',
+                    }}
+                  >
+                    {(result.score * 100).toFixed(1)}% match
+                  </span>
+                  {result.message && (
+                    <span className="message-date">
+                      {new Date(result.message.date).toLocaleDateString()}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="message-text">
+                {result.message?.text || result.text_preview}
+              </div>
+              {result.message && (
+                <div className="message-badges">
+                  {result.message.sentiment_label && (
+                    <span className={`badge badge-${result.message.sentiment_label}`}>
+                      {result.message.sentiment_label}
+                    </span>
+                  )}
+                  {result.message.is_toxic && <span className="badge badge-toxic">Toxic</span>}
+                  {result.message.is_humorous && <span className="badge badge-humor">Humor</span>}
+                </div>
+              )}
+            </div>
+          ))}
+        </>
+      ) : query && !loading ? (
+        <div style={{ textAlign: 'center', padding: 'var(--spacing-xl)', color: 'var(--text-muted)' }}>
+          No results found for "{query}"
+        </div>
+      ) : null}
+
+      {/* Help text */}
+      {!query && searchAvailable && (
+        <div style={{ textAlign: 'center', padding: 'var(--spacing-xl)', color: 'var(--text-muted)' }}>
+          <p style={{ marginBottom: 'var(--spacing-sm)' }}>
+            Enter a search query to find semantically similar messages
+          </p>
+          <p style={{ fontSize: '12px' }}>
+            The search converts your query to an embedding and finds messages with similar meaning
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/ml-dashboard/frontend/src/pages/TopicsPage.tsx
+++ b/apps/ml-dashboard/frontend/src/pages/TopicsPage.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect } from 'react'
+import { useChat } from '../App'
+import { api } from '../api/client'
+import type { Topic, Message } from '../types'
+
+function TopicCard({ topic, onClick }: { topic: Topic; onClick: () => void }) {
+  return (
+    <div className="topic-card" onClick={onClick}>
+      <div className="topic-header">
+        <span className="topic-id">Topic #{topic.topic_id}</span>
+        <span className="topic-count">{topic.actual_count} messages</span>
+      </div>
+      <div className="topic-keywords">
+        {(topic.keywords || []).slice(0, 8).map((keyword, i) => (
+          <span key={i} className="keyword-tag">{keyword}</span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TopicMessages({
+  chatId,
+  topicId,
+  onClose,
+}: {
+  chatId: number
+  topicId: number
+  onClose: () => void
+}) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [loading, setLoading] = useState(true)
+  const [total, setTotal] = useState(0)
+
+  useEffect(() => {
+    api
+      .getTopicMessages(chatId, topicId, 50, 0)
+      .then((res) => {
+        setMessages(res.messages)
+        setTotal(res.total)
+      })
+      .finally(() => setLoading(false))
+  }, [chatId, topicId])
+
+  return (
+    <div className="card" style={{ marginBottom: 'var(--spacing-lg)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-md)' }}>
+        <div>
+          <div style={{ fontWeight: 600, fontSize: '16px' }}>Topic #{topicId}</div>
+          <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+            {total} messages in this topic
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'var(--text-muted)',
+            fontSize: '20px',
+            cursor: 'pointer',
+          }}
+        >
+          &times;
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="loading">Loading messages...</div>
+      ) : (
+        <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+          {messages.map((msg) => {
+            const userName = msg.first_name
+              ? `${msg.first_name}${msg.last_name ? ' ' + msg.last_name : ''}`
+              : msg.username || 'Unknown'
+
+            return (
+              <div
+                key={msg.id}
+                style={{
+                  padding: 'var(--spacing-sm)',
+                  borderBottom: '1px solid var(--border-subtle)',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+                  <span style={{ fontWeight: 500, fontSize: '13px' }}>{userName}</span>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-muted)' }}>
+                    {((msg as Message & { similarity?: number }).similarity * 100).toFixed(0)}% match
+                  </span>
+                </div>
+                <div style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
+                  {msg.text.length > 200 ? msg.text.slice(0, 200) + '...' : msg.text}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function TopicsPage() {
+  const { chatId } = useChat()
+  const [topics, setTopics] = useState<Topic[]>([])
+  const [outlierCount, setOutlierCount] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [selectedTopicId, setSelectedTopicId] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!chatId) return
+    setLoading(true)
+    api
+      .getTopics(chatId)
+      .then((res) => {
+        setTopics(res.topics)
+        setOutlierCount(res.outlier_count)
+      })
+      .finally(() => setLoading(false))
+  }, [chatId])
+
+  if (!chatId) {
+    return <div className="loading">Select a chat to view topics</div>
+  }
+
+  if (loading) {
+    return <div className="loading">Loading topics...</div>
+  }
+
+  return (
+    <div>
+      <header className="page-header">
+        <h1 className="page-title">Topic Clusters</h1>
+        <p className="page-subtitle">
+          {topics.length} topics discovered | {outlierCount.toLocaleString()} unclustered messages
+        </p>
+      </header>
+
+      {/* Selected topic detail */}
+      {selectedTopicId !== null && (
+        <TopicMessages
+          chatId={chatId}
+          topicId={selectedTopicId}
+          onClose={() => setSelectedTopicId(null)}
+        />
+      )}
+
+      {/* Topics grid */}
+      {topics.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: 'var(--spacing-xl)', color: 'var(--text-muted)' }}>
+          <p>No topics found.</p>
+          <p style={{ fontSize: '12px', marginTop: '8px' }}>
+            Topics are generated by clustering message embeddings. Run the ML processor to generate topics.
+          </p>
+        </div>
+      ) : (
+        <div className="topics-grid">
+          {topics.map((topic) => (
+            <TopicCard
+              key={topic.topic_id}
+              topic={topic}
+              onClick={() => setSelectedTopicId(topic.topic_id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/ml-dashboard/frontend/src/pages/UsersPage.tsx
+++ b/apps/ml-dashboard/frontend/src/pages/UsersPage.tsx
@@ -1,0 +1,292 @@
+import { useState, useEffect } from 'react'
+import { useChat } from '../App'
+import { api } from '../api/client'
+import type { User, UserProfile, UserCard } from '../types'
+
+function UserAvatar({ user }: { user: User }) {
+  const initial = (user.first_name?.[0] || user.username?.[0] || '?').toUpperCase()
+  return <div className="user-avatar">{initial}</div>
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return '-'
+  return `${(value * 100).toFixed(1)}%`
+}
+
+function formatSentiment(value: number | null): string {
+  if (value === null) return '-'
+  if (value > 0.1) return `+${value.toFixed(2)}`
+  if (value < -0.1) return value.toFixed(2)
+  return '~0'
+}
+
+function UserDetail({
+  chatId,
+  userId,
+  onClose,
+}: {
+  chatId: number
+  userId: number
+  onClose: () => void
+}) {
+  const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [cards, setCards] = useState<UserCard[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    Promise.all([
+      api.getUserProfile(chatId, userId),
+      api.getUserCards(chatId, userId),
+    ])
+      .then(([profileRes, cardsRes]) => {
+        setProfile(profileRes)
+        setCards(cardsRes.cards)
+      })
+      .finally(() => setLoading(false))
+  }, [chatId, userId])
+
+  if (loading) {
+    return (
+      <div className="card" style={{ marginBottom: 'var(--spacing-lg)' }}>
+        <div className="loading">Loading profile...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="card" style={{ marginBottom: 'var(--spacing-lg)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 'var(--spacing-md)' }}>
+        <div style={{ fontWeight: 600, fontSize: '16px' }}>User Profile</div>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'var(--text-muted)',
+            fontSize: '20px',
+            cursor: 'pointer',
+          }}
+        >
+          &times;
+        </button>
+      </div>
+
+      {profile && (
+        <>
+          {/* Sentiment Distribution */}
+          <div style={{ marginBottom: 'var(--spacing-lg)' }}>
+            <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px' }}>
+              SENTIMENT DISTRIBUTION
+            </div>
+            <div style={{ display: 'flex', gap: 'var(--spacing-md)' }}>
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: '18px', color: 'var(--sentiment-positive)' }}>
+                  {profile.sentiment_distribution.percentages.positive || 0}%
+                </div>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Positive</div>
+              </div>
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: '18px', color: 'var(--sentiment-neutral)' }}>
+                  {profile.sentiment_distribution.percentages.neutral || 0}%
+                </div>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Neutral</div>
+              </div>
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: '18px', color: 'var(--sentiment-negative)' }}>
+                  {profile.sentiment_distribution.percentages.negative || 0}%
+                </div>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Negative</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Entity Mentions */}
+          {profile.entity_mentions.length > 0 && (
+            <div style={{ marginBottom: 'var(--spacing-lg)' }}>
+              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px' }}>
+                TOP ENTITY MENTIONS
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                {profile.entity_mentions.slice(0, 10).map((e, i) => (
+                  <span key={i} className="badge badge-entity">
+                    {e.entity_text} ({e.count})
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Cards History */}
+      {cards.length > 0 && (
+        <div>
+          <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px' }}>
+            CARD HISTORY ({cards.length} cards)
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', maxHeight: '200px', overflowY: 'auto' }}>
+            {cards.map((card) => (
+              <div
+                key={card.id}
+                style={{
+                  padding: '8px',
+                  backgroundColor: 'var(--bg-tertiary)',
+                  borderRadius: '4px',
+                  fontSize: '13px',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span>Week of {new Date(card.week_start).toLocaleDateString()}</span>
+                  {card.image_url && (
+                    <span style={{ color: 'var(--accent-green)' }}>Has image</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function UsersPage() {
+  const { chatId } = useChat()
+  const [users, setUsers] = useState<User[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null)
+
+  const limit = 50
+
+  useEffect(() => {
+    if (!chatId) return
+    setLoading(true)
+    api
+      .getUsers(chatId, limit, offset)
+      .then((res) => {
+        setUsers(res.users)
+        setTotal(res.total)
+      })
+      .finally(() => setLoading(false))
+  }, [chatId, offset])
+
+  if (!chatId) {
+    return <div className="loading">Select a chat to view users</div>
+  }
+
+  return (
+    <div>
+      <header className="page-header">
+        <h1 className="page-title">User Analytics</h1>
+        <p className="page-subtitle">Aggregated ML statistics by user</p>
+      </header>
+
+      {/* Selected user detail */}
+      {selectedUserId && (
+        <UserDetail
+          chatId={chatId}
+          userId={selectedUserId}
+          onClose={() => setSelectedUserId(null)}
+        />
+      )}
+
+      {/* Users table */}
+      {loading ? (
+        <div className="loading">Loading users...</div>
+      ) : (
+        <>
+          <div style={{ marginBottom: 'var(--spacing-md)', color: 'var(--text-secondary)', fontSize: '13px' }}>
+            Showing {offset + 1}-{Math.min(offset + users.length, total)} of {total} users
+          </div>
+
+          <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Messages</th>
+                  <th>Sentiment</th>
+                  <th>Toxicity</th>
+                  <th>Humor</th>
+                  <th>Questions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => {
+                  const name = user.first_name
+                    ? `${user.first_name}${user.last_name ? ' ' + user.last_name : ''}`
+                    : user.username || 'Unknown'
+
+                  return (
+                    <tr
+                      key={user.user_id}
+                      onClick={() => setSelectedUserId(user.user_id)}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <td>
+                        <div className="user-row">
+                          <UserAvatar user={user} />
+                          <div>
+                            <div className="user-name">{name}</div>
+                            {user.username && (
+                              <div className="user-username">@{user.username}</div>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="mono">{user.message_count.toLocaleString()}</td>
+                      <td className="mono" style={{
+                        color: (user.avg_sentiment || 0) > 0.1
+                          ? 'var(--sentiment-positive)'
+                          : (user.avg_sentiment || 0) < -0.1
+                            ? 'var(--sentiment-negative)'
+                            : 'var(--text-secondary)'
+                      }}>
+                        {formatSentiment(user.avg_sentiment)}
+                      </td>
+                      <td className="mono" style={{
+                        color: (user.toxicity_rate || 0) > 0.1
+                          ? 'var(--accent-red)'
+                          : 'var(--text-secondary)'
+                      }}>
+                        {formatPercent(user.toxicity_rate)}
+                      </td>
+                      <td className="mono" style={{ color: 'var(--accent-purple)' }}>
+                        {formatPercent(user.humor_rate)}
+                      </td>
+                      <td className="mono" style={{ color: 'var(--accent-blue)' }}>
+                        {formatPercent(user.question_rate)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pagination">
+            <button
+              className="pagination-btn"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - limit))}
+            >
+              Previous
+            </button>
+            <span className="pagination-info">
+              Page {Math.floor(offset / limit) + 1} of {Math.ceil(total / limit)}
+            </span>
+            <button
+              className="pagination-btn"
+              disabled={offset + limit >= total}
+              onClick={() => setOffset(offset + limit)}
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/ml-dashboard/frontend/src/styles/global.css
+++ b/apps/ml-dashboard/frontend/src/styles/global.css
@@ -1,0 +1,586 @@
+:root {
+  /* Dark theme - terminal/IDE aesthetic */
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #21262d;
+  --bg-hover: #30363d;
+
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+
+  --border-color: #30363d;
+  --border-subtle: #21262d;
+
+  /* Accent colors */
+  --accent-blue: #58a6ff;
+  --accent-green: #3fb950;
+  --accent-red: #f85149;
+  --accent-orange: #d29922;
+  --accent-purple: #a371f7;
+  --accent-cyan: #39c5cf;
+
+  /* ML-specific colors */
+  --sentiment-positive: #3fb950;
+  --sentiment-neutral: #8b949e;
+  --sentiment-negative: #f85149;
+  --toxicity: #f85149;
+  --humor: #a371f7;
+  --question: #58a6ff;
+  --entity: #39c5cf;
+
+  /* Typography */
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+
+  /* Spacing */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 32px;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Layout */
+.app-layout {
+  display: flex;
+  height: 100%;
+}
+
+.sidebar {
+  width: 240px;
+  background-color: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.sidebar-header {
+  padding: var(--spacing-lg);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.sidebar-title {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--accent-cyan);
+}
+
+.sidebar-subtitle {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: var(--spacing-xs);
+}
+
+.sidebar-nav {
+  padding: var(--spacing-md);
+  flex: 1;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  transition: all 0.15s ease;
+}
+
+.nav-link:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.nav-link.active {
+  background-color: var(--bg-tertiary);
+  color: var(--accent-blue);
+}
+
+.nav-icon {
+  font-size: 18px;
+  width: 24px;
+  text-align: center;
+}
+
+.sidebar-footer {
+  padding: var(--spacing-md);
+  border-top: 1px solid var(--border-color);
+}
+
+.chat-selector {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.chat-selector:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-xl);
+}
+
+/* Page header */
+.page-header {
+  margin-bottom: var(--spacing-xl);
+}
+
+.page-title {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.page-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-top: var(--spacing-xs);
+}
+
+/* Cards */
+.card {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+}
+
+.card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-md);
+}
+
+.card-value {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.card-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: var(--spacing-xs);
+}
+
+/* Stats grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-md);
+}
+
+/* Tables */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: var(--spacing-sm) var(--spacing-md);
+  text-align: left;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.data-table th {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background-color: var(--bg-tertiary);
+}
+
+.data-table tr:hover td {
+  background-color: var(--bg-hover);
+}
+
+.data-table .mono {
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+/* Badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.badge-positive {
+  background-color: rgba(63, 185, 80, 0.15);
+  color: var(--sentiment-positive);
+}
+
+.badge-neutral {
+  background-color: rgba(139, 148, 158, 0.15);
+  color: var(--sentiment-neutral);
+}
+
+.badge-negative {
+  background-color: rgba(248, 81, 73, 0.15);
+  color: var(--sentiment-negative);
+}
+
+.badge-toxic {
+  background-color: rgba(248, 81, 73, 0.15);
+  color: var(--toxicity);
+}
+
+.badge-humor {
+  background-color: rgba(163, 113, 247, 0.15);
+  color: var(--humor);
+}
+
+.badge-question {
+  background-color: rgba(88, 166, 255, 0.15);
+  color: var(--question);
+}
+
+.badge-entity {
+  background-color: rgba(57, 197, 207, 0.15);
+  color: var(--entity);
+}
+
+/* Filters */
+.filters-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+  padding: var(--spacing-md);
+  background-color: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.filter-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.filter-select,
+.filter-input {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background-color: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 13px;
+  min-width: 120px;
+}
+
+.filter-select:focus,
+.filter-input:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+/* Search input */
+.search-container {
+  position: relative;
+  margin-bottom: var(--spacing-lg);
+}
+
+.search-input {
+  width: 100%;
+  padding: var(--spacing-md) var(--spacing-lg);
+  padding-left: 48px;
+  background-color: var(--bg-secondary);
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  color: var(--text-primary);
+  font-size: 16px;
+  transition: border-color 0.15s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.search-icon {
+  position: absolute;
+  left: var(--spacing-md);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  font-size: 20px;
+}
+
+/* Message card */
+.message-card {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-sm);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.message-card:hover {
+  border-color: var(--accent-blue);
+}
+
+.message-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--spacing-sm);
+}
+
+.message-user {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.message-date {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.message-text {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: var(--spacing-sm);
+  word-break: break-word;
+}
+
+.message-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+/* Loading & Error states */
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--spacing-xl);
+  color: var(--text-muted);
+}
+
+.error {
+  padding: var(--spacing-lg);
+  background-color: rgba(248, 81, 73, 0.1);
+  border: 1px solid var(--accent-red);
+  border-radius: var(--radius-lg);
+  color: var(--accent-red);
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-lg);
+}
+
+.pagination-btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background-color: var(--bg-hover);
+  border-color: var(--accent-blue);
+}
+
+.pagination-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* Topic card */
+.topic-card {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.topic-card:hover {
+  border-color: var(--accent-purple);
+}
+
+.topic-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+}
+
+.topic-id {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.topic-count {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--accent-purple);
+}
+
+.topic-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.keyword-tag {
+  padding: 2px 8px;
+  background-color: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* Topics grid */
+.topics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--spacing-md);
+}
+
+/* User row */
+.user-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.user-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: var(--bg-tertiary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--accent-blue);
+}
+
+.user-name {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.user-username {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* Progress bar */
+.progress-bar {
+  width: 100%;
+  height: 4px;
+  background-color: var(--bg-tertiary);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background-color: var(--accent-blue);
+  transition: width 0.3s ease;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-primary);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}

--- a/apps/ml-dashboard/frontend/src/types/index.ts
+++ b/apps/ml-dashboard/frontend/src/types/index.ts
@@ -1,0 +1,219 @@
+/**
+ * Type definitions for ML Dashboard.
+ */
+
+// Chat
+export interface Chat {
+  id: number
+  title: string
+  type: string
+  username: string | null
+  message_count: number
+  processed_count: number
+}
+
+// Message with ML results
+export interface Message {
+  id: number
+  message_id: number
+  chat_id: number
+  user_id: number | null
+  text: string
+  date: string
+  first_name: string | null
+  last_name: string | null
+  username: string | null
+  // Sentiment
+  sentiment_label: 'positive' | 'neutral' | 'negative' | null
+  score_positive: number | null
+  score_neutral: number | null
+  score_negative: number | null
+  sentiment_confidence: number | null
+  // Toxicity
+  is_toxic: boolean | null
+  toxicity_label: string | null
+  toxicity_score: number | null
+  // Humor
+  is_humorous: boolean | null
+  humor_type: string | null
+  humor_score: number | null
+  // Questions
+  is_question: boolean | null
+  question_type: string | null
+  question_score: number | null
+  // Topic
+  topic_id: number | null
+  topic_similarity: number | null
+}
+
+export interface Entity {
+  entity_type: string
+  entity_text: string
+  start_pos: number | null
+  end_pos: number | null
+  confidence: number | null
+}
+
+export interface MessageDetail {
+  message: Message
+  entities: Entity[]
+}
+
+// Messages API response
+export interface MessagesResponse {
+  messages: Message[]
+  total: number
+  page_info: {
+    limit: number
+    offset: number
+    has_more: boolean
+  }
+}
+
+// Topic
+export interface Topic {
+  topic_id: number
+  keywords: string[]
+  message_count: number
+  actual_count: number
+}
+
+export interface TopicsResponse {
+  topics: Topic[]
+  total_topics: number
+  outlier_count: number
+}
+
+// User with ML stats
+export interface User {
+  user_id: number
+  first_name: string | null
+  last_name: string | null
+  username: string | null
+  message_count: number
+  avg_sentiment: number | null
+  toxicity_rate: number | null
+  humor_rate: number | null
+  question_rate: number | null
+}
+
+export interface UsersResponse {
+  users: User[]
+  total: number
+  page_info: {
+    limit: number
+    offset: number
+    has_more: boolean
+  }
+}
+
+export interface SentimentDistribution {
+  counts: {
+    total: number
+    positive: number
+    neutral: number
+    negative: number
+  }
+  percentages: {
+    positive: number
+    neutral: number
+    negative: number
+  }
+}
+
+export interface EntityMention {
+  entity_type: string
+  entity_text: string
+  count: number
+}
+
+export interface UserProfile {
+  user_id: number
+  sentiment_distribution: SentimentDistribution
+  entity_mentions: EntityMention[]
+}
+
+export interface UserCard {
+  id: number
+  user_id: number
+  chat_id: number
+  week_start: string
+  week_end: string
+  stats: Record<string, unknown>
+  trends: Record<string, unknown>
+  image_url: string | null
+  created_at: string
+}
+
+export interface UserCardsResponse {
+  user_id: number
+  cards: UserCard[]
+  total: number
+}
+
+// Search
+export interface SearchResult {
+  message_id: number
+  score: number
+  text_preview: string
+  message: Message | null
+}
+
+export interface SearchResponse {
+  results: SearchResult[]
+  query: string
+  timing: {
+    embedding_ms: number
+    search_ms: number
+  }
+}
+
+export interface SearchStatus {
+  qdrant: {
+    available: boolean
+    points_count: number
+    status: string
+  }
+  embedding_model_loaded: boolean
+  search_available: boolean
+}
+
+// Stats
+export interface ProcessingStats {
+  total_with_text: number
+  processed: number
+  sentiment_count: number
+  toxicity_count: number
+  toxic_count: number
+  humor_count: number
+  humorous_count: number
+  questions_count: number
+  question_count: number
+  entity_count: number
+  topic_count: number
+}
+
+export interface StatsResponse {
+  processing: ProcessingStats
+  qdrant: {
+    available: boolean
+    points_count: number
+    status: string
+  }
+}
+
+export interface ChatsResponse {
+  chats: Chat[]
+}
+
+// Filter options
+export interface MessageFilters {
+  user_id?: number
+  sentiment?: 'positive' | 'neutral' | 'negative'
+  is_toxic?: boolean
+  is_humorous?: boolean
+  is_question?: boolean
+  topic_id?: number
+  sort_by?: 'date' | 'toxicity_score' | 'sentiment_score'
+  sort_order?: 'asc' | 'desc'
+}

--- a/apps/ml-dashboard/frontend/src/vite-env.d.ts
+++ b/apps/ml-dashboard/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/apps/ml-dashboard/frontend/tsconfig.json
+++ b/apps/ml-dashboard/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/apps/ml-dashboard/frontend/vite.config.ts
+++ b/apps/ml-dashboard/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5175,
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+  },
+})

--- a/infrastructure/docker-compose.dev.yml
+++ b/infrastructure/docker-compose.dev.yml
@@ -281,6 +281,50 @@ services:
     networks:
       - beef-dev-network
 
+  # ML Dashboard - Dev-only tool for exploring ML data
+  ml-dashboard-backend:
+    build:
+      context: ..
+      dockerfile: apps/ml-dashboard/backend/Dockerfile
+    container_name: beef-ml-dashboard-backend-dev
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      DB_SSL_MODE: disable
+      QDRANT_HOST: qdrant
+      QDRANT_PORT: 6333
+      QDRANT_ENABLED: "true"
+      ENVIRONMENT: development
+      LOG_LEVEL: debug
+    ports:
+      - "8052:8052"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - postgres
+      - qdrant
+    networks:
+      - beef-dev-network
+    restart: unless-stopped
+
+  ml-dashboard-frontend:
+    image: node:22-alpine
+    container_name: beef-ml-dashboard-frontend-dev
+    working_dir: /app
+    volumes:
+      - ../apps/ml-dashboard/frontend:/app
+      - ml_dashboard_node_modules_dev:/app/node_modules
+    ports:
+      - "5175:5175"
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    environment:
+      VITE_API_URL: http://localhost:8052
+    networks:
+      - beef-dev-network
+
 volumes:
   postgres_data_dev:
   minio_data_dev:
@@ -288,6 +332,7 @@ volumes:
   ml_models_cache_dev:
   deck_mini_app_node_modules_dev:
   leaderboard_mini_app_node_modules_dev:
+  ml_dashboard_node_modules_dev:
 
 networks:
   beef-dev-network:


### PR DESCRIPTION
# ML Dashboard

## Summary

- Add a development-only web dashboard for exploring ML-processed Telegram data
- Implement React + FastAPI architecture with semantic search via Qdrant
- Provide visual tools for browsing messages, topics, users, and ML annotations
- Clean up unused Media page code from leaderboard-mini-app

## Overview

The ML Dashboard is a dev tool for visualizing and debugging the machine learning pipeline results from ml-processor. It connects to PostgreSQL for ML annotations and Qdrant for semantic vector search.

### Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                    ML Dashboard                              │
├─────────────────────────┬───────────────────────────────────┤
│   Frontend (React)      │        Backend (FastAPI)          │
│   Port: 5175            │        Port: 8052                 │
│                         │                                   │
│   - Dashboard           │   /api/stats      - Stats         │
│   - Messages Browser    │   /api/messages   - ML results    │
│   - Semantic Search     │   /api/search     - Qdrant search │
│   - Topic Explorer      │   /api/topics     - Clusters      │
│   - User Analytics      │   /api/users      - User stats    │
└─────────────────────────┴───────────────────────────────────┘
            │                           │
            │                           ├──► PostgreSQL (ML tables)
            │                           └──► Qdrant (embeddings)
```

## Features

### Dashboard Page
- ML processing progress visualization
- Analysis counts (sentiment, toxicity, humor, questions, entities, topics)
- Qdrant connection status and embedding count

### Messages Browser
- Paginated message list with ML annotations
- Advanced filtering: sentiment, toxicity, humor, questions, topic cluster
- Sorting by date, toxicity score, or sentiment score
- Expandable details with named entities

### Semantic Search
- Text-to-vector search using Sentence Transformers
- Real-time similarity scoring with timing metrics
- Graceful degradation when Qdrant is unavailable

### Topic Explorer
- Grid view of discovered topic clusters with keywords
- Drill-down into topic messages
- Outlier (unclustered) message count

### User Analytics
- Aggregated ML stats per user (avg sentiment, toxicity rate, humor rate)
- User profile modal with sentiment distribution
- Top entity mentions and card history

## Tech Stack

**Frontend:** React 18, TypeScript, Vite, React Router
**Backend:** FastAPI, SQLAlchemy, Sentence Transformers, Qdrant client
**Styling:** Custom dark theme with design tokens (no UI framework)

## Usage

```bash
# Start the dashboard
make ml-dashboard-up-build

# Access at http://localhost:5175

# View logs
make ml-dashboard-logs
```

## Changes

### Added
- `apps/ml-dashboard/` - Complete dashboard implementation
  - `backend/` - FastAPI service with 15+ API endpoints
  - `frontend/` - React SPA with 5 pages
- Makefile targets for ml-dashboard lifecycle
- Docker Compose services for frontend and backend

### Removed
- Unused Media page from leaderboard-mini-app (436 lines)
- Related API client methods and types

## Test Plan

- [ ] Start dashboard with `make ml-dashboard-up-build`
- [ ] Verify Dashboard page shows stats and progress
- [ ] Test Messages page filtering (sentiment, toxicity, etc.)
- [ ] Test Semantic Search (requires Qdrant with embeddings)
- [ ] Verify Topics page shows clusters
- [ ] Test Users page with profile modal
- [ ] Confirm graceful degradation when Qdrant is unavailable

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
