### PR TITLE
make deploy Layer-Aware Docker Image Transfer 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,50 @@ prod-update-ip: ## Update IP allowlist for api-service and card-renderer
 	scp $(PROD_ENV_FILE) $$($(MAKE) -s tf-ssh-user-host):~/beef-briefing/.env; \
 	ssh $$($(MAKE) -s tf-ssh-user-host) 'cd ~/beef-briefing && docker compose up -d --force-recreate --no-deps api-service card-renderer'
 
+# =============================================================================
+# LAYER CACHE (layer-cache-*)
+# =============================================================================
+layer-cache-clean: ## Clean local OCI layer cache
+	@rm -rf /tmp/beef-briefing-oci-cache
+	@echo "Local layer cache cleaned"
+
+layer-cache-clean-remote: ## Clean remote OCI layer cache
+	@ssh $$($(MAKE) -s tf-ssh-user-host) 'rm -rf ~/beef-briefing/.oci-cache'
+	@echo "Remote layer cache cleaned"
+
+layer-cache-stats: ## Show layer cache statistics (local and remote)
+	@echo "Layer Cache Statistics"
+	@echo "======================"
+	@echo ""
+	@echo "Local cache (/tmp/beef-briefing-oci-cache):"
+	@if [ -d /tmp/beef-briefing-oci-cache ]; then \
+		ls -1 /tmp/beef-briefing-oci-cache 2>/dev/null | while read dir; do \
+			size=$$(du -sh "/tmp/beef-briefing-oci-cache/$$dir" 2>/dev/null | cut -f1); \
+			blobs=0; \
+			if [ -d "/tmp/beef-briefing-oci-cache/$$dir/blobs/sha256" ]; then \
+				blobs=$$(ls -1 "/tmp/beef-briefing-oci-cache/$$dir/blobs/sha256" 2>/dev/null | wc -l); \
+			fi; \
+			echo "  $$dir: $$size ($$blobs blobs)"; \
+		done; \
+	else \
+		echo "  (no cache)"; \
+	fi
+	@echo ""
+	@echo "Remote cache (~/beef-briefing/.oci-cache):"
+	@ssh $$($(MAKE) -s tf-ssh-user-host) '\
+		if [ -d ~/beef-briefing/.oci-cache ]; then \
+			ls -1 ~/beef-briefing/.oci-cache 2>/dev/null | while read dir; do \
+				size=$$(du -sh "$$HOME/beef-briefing/.oci-cache/$$dir" 2>/dev/null | cut -f1); \
+				blobs=0; \
+				if [ -d "$$HOME/beef-briefing/.oci-cache/$$dir/blobs/sha256" ]; then \
+					blobs=$$(ls -1 "$$HOME/beef-briefing/.oci-cache/$$dir/blobs/sha256" 2>/dev/null | wc -l); \
+				fi; \
+				echo "  $$dir: $$size ($$blobs blobs)"; \
+			done; \
+		else \
+			echo "  (no cache)"; \
+		fi' 2>/dev/null || echo "  (unable to connect)"
+
 pg-tunnel: ## Open SSH tunnel to production PostgreSQL (localhost:5433 -> prod postgres)
 	@echo "Opening SSH tunnel to production PostgreSQL..."
 	@echo "Connect locally using: psql -h localhost -p 5433 -U postgres -d beef_briefing"
@@ -715,7 +759,9 @@ mc-setup-prod: ## Configure MinIO Client alias for production
 	up build deploy \
 	dev-up dev-up-build dev-up-logs dev-down dev-restart dev-ps dev-clean dev-prune \
 	prod-deploy prod-deploy-skip-build prod-deploy-skip-cleanup prod-deploy-regenerate-certs \
-	prod-rollback prod-rollback-force prod-backup-db prod-clean-certs prod-logs-traefik prod-update-ip pg-tunnel pg-dev pg-prod \
+	prod-rollback prod-rollback-force prod-backup-db prod-clean-certs prod-logs-traefik prod-update-ip \
+	layer-cache-clean layer-cache-clean-remote layer-cache-stats \
+	pg-tunnel pg-dev pg-prod \
 	docker-build docker-build-api docker-build-bot \
 	docker-logs docker-logs-api docker-logs-bot docker-logs-postgres docker-logs-minio \
 	docker-logs-newrelic \

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -17,6 +17,10 @@ SECRETS_DIR="$PROJECT_ROOT/infrastructure/secrets/apps"
 REMOTE_APP_DIR="~/beef-briefing"
 REMOTE_PREVIOUS_TAG_FILE="$REMOTE_APP_DIR/.previous_tag"
 
+# Layer cache directories (for OCI-format image transfer)
+LAYER_CACHE_DIR="/tmp/beef-briefing-oci-cache"
+REMOTE_LAYER_CACHE_DIR="$REMOTE_APP_DIR/.oci-cache"
+
 # Images to manage
 IMAGES=(
     "beef-briefing/api-service"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -155,23 +155,15 @@ else
 fi
 
 # =============================================================================
-# SAVE AND TRANSFER IMAGES
+# LAYER-AWARE IMAGE TRANSFER
 # =============================================================================
-log_step "Saving images to tarball..."
-IMAGE_TARBALL="/tmp/images-${COMMIT_HASH}.tar.gz"
+# Source layer transfer functions
+source "$SCRIPT_DIR/layer-transfer.sh"
 
-# Build image list with tags from IMAGES array
-IMAGE_ARGS=""
-for image in "${IMAGES[@]}"; do
-    IMAGE_ARGS="$IMAGE_ARGS $image:$COMMIT_HASH"
-done
+# Transfer images using OCI directory format (only changed layers)
+transfer_images "$COMMIT_HASH" "$SSH_HOST"
 
-docker save $IMAGE_ARGS | gzip > "$IMAGE_TARBALL"
-
-TARBALL_SIZE=$(du -h "$IMAGE_TARBALL" | cut -f1)
-log_success "Image archive created: $TARBALL_SIZE"
-
-log_step "Transferring files to server..."
+log_step "Transferring config files to server..."
 
 # Transfer compose file
 log_info "Transferring docker-compose.yml..."
@@ -191,11 +183,7 @@ if [[ "$HAS_LETSENCRYPT" == "true" ]]; then
     remote_copy "$LETSENCRYPT_DIR" "$SSH_HOST" "/tmp/"
 fi
 
-# Transfer image tarball
-log_info "Transferring images ($TARBALL_SIZE)..."
-remote_copy "$IMAGE_TARBALL" "$SSH_HOST" "/tmp/"
-
-log_success "All files transferred"
+log_success "All config files transferred"
 
 # =============================================================================
 # DEPLOY ON SERVER
@@ -231,10 +219,7 @@ remote_exec "$SSH_HOST" "
         echo 'Created acme.json for Let'\''s Encrypt'
     fi
 
-    # Load Docker images WHILE containers are still running (minimizes downtime)
-    echo 'Loading Docker images...'
-    gunzip -c /tmp/images-${COMMIT_HASH}.tar.gz | docker load
-
+    # Images already loaded by layer-aware transfer (transfer_images function)
     # NOW stop containers (just before replacing secrets - minimizes downtime)
     echo 'Stopping containers for secrets update...'
     cd ~/beef-briefing && docker compose down 2>/dev/null || true
@@ -249,50 +234,47 @@ remote_exec "$SSH_HOST" "
     echo 'Starting services...'
     cd ~/beef-briefing && docker compose up -d --no-build
 
-    # Cleanup tarball
-    rm /tmp/images-${COMMIT_HASH}.tar.gz
-
     echo 'Deployment complete!'
 "
 
 log_success "Services deployed with tag: $COMMIT_HASH"
 
 # =============================================================================
-# CLEANUP OLD IMAGES
+# CLEANUP OLD IMAGES AND LAYER CACHE
 # =============================================================================
-if [[ "$SKIP_CLEANUP" == "false" && -n "$PREVIOUS_TAG" ]]; then
-    log_step "Cleaning up old images on server..."
+if [[ "$SKIP_CLEANUP" == "false" ]]; then
+    log_step "Cleaning up old images and layer cache..."
 
-    remote_exec "$SSH_HOST" "
-        # Get all tags for beef-briefing images
-        CURRENT_TAG='$COMMIT_HASH'
-        PREVIOUS_TAG='$PREVIOUS_TAG'
+    # Cleanup Docker images (keep current and previous)
+    if [[ -n "$PREVIOUS_TAG" ]]; then
+        remote_exec "$SSH_HOST" "
+            # Get all tags for beef-briefing images
+            CURRENT_TAG='$COMMIT_HASH'
+            PREVIOUS_TAG='$PREVIOUS_TAG'
 
-        # Find and remove old images (keep only current and previous)
-        for repo in beef-briefing/api-service beef-briefing/telegram-bot beef-briefing/card-renderer; do
-            docker images \"\$repo\" --format '{{.Tag}}' | while read tag; do
-                if [[ \"\$tag\" != \"\$CURRENT_TAG\" && \"\$tag\" != \"\$PREVIOUS_TAG\" && \"\$tag\" != '<none>' ]]; then
-                    echo \"Removing \$repo:\$tag\"
-                    docker rmi \"\$repo:\$tag\" 2>/dev/null || true
-                fi
+            # Find and remove old images (keep only current and previous)
+            for repo in beef-briefing/api-service beef-briefing/telegram-bot beef-briefing/card-renderer; do
+                docker images \"\$repo\" --format '{{.Tag}}' | while read tag; do
+                    if [[ \"\$tag\" != \"\$CURRENT_TAG\" && \"\$tag\" != \"\$PREVIOUS_TAG\" && \"\$tag\" != '<none>' ]]; then
+                        echo \"Removing \$repo:\$tag\"
+                        docker rmi \"\$repo:\$tag\" 2>/dev/null || true
+                    fi
+                done
             done
-        done
 
-        # Prune dangling images
-        docker image prune -f
-    " || log_warn "Image cleanup had some warnings (non-fatal)"
+            # Prune dangling images
+            docker image prune -f
+        " || log_warn "Image cleanup had some warnings (non-fatal)"
+    fi
 
-    log_success "Old images cleaned up"
+    # Cleanup OCI layer cache (keep last 2 versions)
+    cleanup_local_cache 2
+    cleanup_remote_cache "$SSH_HOST" 2
+
+    log_success "Cleanup complete"
 else
-    log_warn "Skipping cleanup (--skip-cleanup or no previous tag)"
+    log_warn "Skipping cleanup (--skip-cleanup)"
 fi
-
-# =============================================================================
-# CLEANUP LOCAL TARBALL
-# =============================================================================
-log_info "Cleaning up local tarball..."
-rm -f "$IMAGE_TARBALL"
-log_success "Local cleanup complete"
 
 # =============================================================================
 # SUMMARY

--- a/scripts/layer-transfer.sh
+++ b/scripts/layer-transfer.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Layer-aware Docker image transfer using OCI directory format + rsync
+# Usage: source this file, then call transfer_images
+#
+# This script transfers Docker images to a remote server by:
+# 1. Exporting images to OCI directory format (content-addressed blobs)
+# 2. Using rsync to transfer only changed blobs
+# 3. Loading images from the OCI directory on the remote server
+#
+# This is much faster than the traditional docker save | gzip | scp approach
+# when only a few layers have changed (e.g., code-only changes).
+
+set -e
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+LAYER_CACHE_DIR="${LAYER_CACHE_DIR:-/tmp/beef-briefing-oci-cache}"
+REMOTE_LAYER_CACHE_DIR="${REMOTE_LAYER_CACHE_DIR:-~/beef-briefing/.oci-cache}"
+
+# =============================================================================
+# OCI DIRECTORY FUNCTIONS
+# =============================================================================
+
+# Extract images to OCI directory format
+# Args: $1 = tag
+# Returns: path to OCI directory (via stdout)
+prepare_oci_directory() {
+    local tag="$1"
+    local oci_dir="${LAYER_CACHE_DIR}/${tag}"
+
+    # Clean up any existing directory for this tag
+    rm -rf "$oci_dir"
+    mkdir -p "$oci_dir"
+
+    # Build image list from IMAGES array (defined in common.sh)
+    local image_args=""
+    for image in "${IMAGES[@]}"; do
+        image_args="$image_args $image:$tag"
+    done
+
+    # Redirect log output to stderr so it doesn't get captured with the return value
+    log_info "Extracting images to OCI directory..." >&2
+    # docker save produces OCI-layout format, extract to directory
+    docker save $image_args | tar -xf - -C "$oci_dir"
+
+    # Count blobs and calculate size
+    local blob_count=0
+    local total_size="0"
+    if [[ -d "$oci_dir/blobs/sha256" ]]; then
+        blob_count=$(ls -1 "$oci_dir/blobs/sha256/" 2>/dev/null | wc -l)
+        total_size=$(du -sh "$oci_dir" 2>/dev/null | cut -f1)
+    fi
+
+    log_success "OCI directory ready: $blob_count blobs, $total_size total" >&2
+    # Return the directory path (only this goes to stdout)
+    echo "$oci_dir"
+}
+
+# Transfer OCI directory to remote using rsync
+# Args: $1 = oci_dir, $2 = ssh_host, $3 = tag
+transfer_oci_directory() {
+    local oci_dir="$1"
+    local ssh_host="$2"
+    local tag="$3"
+    local remote_dir="${REMOTE_LAYER_CACHE_DIR}/${tag}"
+
+    log_info "Creating remote directory structure..."
+    remote_exec "$ssh_host" "mkdir -p $remote_dir/blobs/sha256"
+
+    log_info "Transferring layers with rsync (only changed blobs)..."
+
+    # rsync options:
+    # -a: archive mode (preserves permissions, timestamps)
+    # -v: verbose output
+    # -z: compress during transfer
+    # --progress: show transfer progress
+    # --checksum: compare by checksum instead of mod-time/size
+    #             This ensures unchanged blobs are skipped even if timestamps differ
+    # -e "ssh -o Compression=no": use SSH without compression (rsync -z handles it)
+    rsync -avz --progress --checksum \
+        -e "ssh -o Compression=no" \
+        "$oci_dir/" \
+        "${ssh_host}:${remote_dir}/"
+
+    log_success "Transfer complete"
+}
+
+# Load images on remote from OCI directory
+# Args: $1 = ssh_host, $2 = tag
+load_images_remote() {
+    local ssh_host="$1"
+    local tag="$2"
+    local remote_dir="${REMOTE_LAYER_CACHE_DIR}/${tag}"
+
+    log_info "Loading images on remote from OCI directory..."
+    remote_exec "$ssh_host" "
+        set -e
+        cd $remote_dir
+
+        # docker load expects a tar stream, create it from the directory
+        tar -cf - . | docker load
+
+        echo 'Images loaded successfully'
+    "
+    log_success "Images loaded on remote"
+}
+
+# Main transfer function - orchestrates the full transfer process
+# Args: $1 = tag (commit hash), $2 = ssh_host
+transfer_images() {
+    local tag="$1"
+    local ssh_host="$2"
+
+    log_step "Preparing OCI directory..."
+    local oci_dir
+    oci_dir=$(prepare_oci_directory "$tag")
+
+    log_step "Transferring to remote (rsync)..."
+    transfer_oci_directory "$oci_dir" "$ssh_host" "$tag"
+
+    log_step "Loading images on remote..."
+    load_images_remote "$ssh_host" "$tag"
+}
+
+# =============================================================================
+# CACHE CLEANUP FUNCTIONS
+# =============================================================================
+
+# Cleanup local OCI cache, keeping the N most recent tags
+# Args: $1 = number of tags to keep (default: 2)
+cleanup_local_cache() {
+    local keep_tags="${1:-2}"
+
+    if [[ ! -d "$LAYER_CACHE_DIR" ]]; then
+        return 0
+    fi
+
+    log_info "Cleaning local OCI cache (keeping last $keep_tags)..."
+
+    # List directories sorted by modification time, remove oldest
+    local dir_count
+    dir_count=$(ls -1 "$LAYER_CACHE_DIR" 2>/dev/null | wc -l)
+
+    if [[ "$dir_count" -gt "$keep_tags" ]]; then
+        ls -t "$LAYER_CACHE_DIR" | tail -n +$((keep_tags + 1)) | while read -r dir; do
+            log_info "  Removing old cache: $dir"
+            rm -rf "${LAYER_CACHE_DIR}/${dir}"
+        done
+    fi
+}
+
+# Cleanup remote OCI cache, keeping the N most recent tags
+# Args: $1 = ssh_host, $2 = number of tags to keep (default: 2)
+cleanup_remote_cache() {
+    local ssh_host="$1"
+    local keep_tags="${2:-2}"
+
+    log_info "Cleaning remote OCI cache (keeping last $keep_tags)..."
+    remote_exec "$ssh_host" "
+        if [[ -d $REMOTE_LAYER_CACHE_DIR ]]; then
+            dir_count=\$(ls -1 $REMOTE_LAYER_CACHE_DIR 2>/dev/null | wc -l)
+            if [[ \"\$dir_count\" -gt $keep_tags ]]; then
+                ls -t $REMOTE_LAYER_CACHE_DIR | tail -n +$((keep_tags + 1)) | while read dir; do
+                    echo \"  Removing old cache: \$dir\"
+                    rm -rf \"${REMOTE_LAYER_CACHE_DIR}/\$dir\"
+                done
+            fi
+        fi
+    " || log_warn "Remote cache cleanup had warnings (non-fatal)"
+}
+
+# =============================================================================
+# STATISTICS FUNCTIONS
+# =============================================================================
+
+# Show local and remote cache statistics
+# Args: $1 = ssh_host
+show_cache_stats() {
+    local ssh_host="$1"
+
+    echo ""
+    echo "Layer Cache Statistics"
+    echo "======================"
+    echo ""
+    echo "Local cache ($LAYER_CACHE_DIR):"
+    if [[ -d "$LAYER_CACHE_DIR" ]]; then
+        ls -1 "$LAYER_CACHE_DIR" 2>/dev/null | while read -r dir; do
+            local size
+            size=$(du -sh "${LAYER_CACHE_DIR}/${dir}" 2>/dev/null | cut -f1)
+            local blobs=0
+            if [[ -d "${LAYER_CACHE_DIR}/${dir}/blobs/sha256" ]]; then
+                blobs=$(ls -1 "${LAYER_CACHE_DIR}/${dir}/blobs/sha256" 2>/dev/null | wc -l)
+            fi
+            echo "  $dir: $size ($blobs blobs)"
+        done
+    else
+        echo "  (no cache)"
+    fi
+
+    echo ""
+    echo "Remote cache ($REMOTE_LAYER_CACHE_DIR):"
+    remote_exec "$ssh_host" "
+        if [[ -d $REMOTE_LAYER_CACHE_DIR ]]; then
+            ls -1 $REMOTE_LAYER_CACHE_DIR 2>/dev/null | while read dir; do
+                size=\$(du -sh \"${REMOTE_LAYER_CACHE_DIR}/\$dir\" 2>/dev/null | cut -f1)
+                blobs=0
+                if [[ -d \"${REMOTE_LAYER_CACHE_DIR}/\$dir/blobs/sha256\" ]]; then
+                    blobs=\$(ls -1 \"${REMOTE_LAYER_CACHE_DIR}/\$dir/blobs/sha256\" 2>/dev/null | wc -l)
+                fi
+                echo \"  \$dir: \$size (\$blobs blobs)\"
+            done
+        else
+            echo '  (no cache)'
+        fi
+    " 2>/dev/null || echo "  (unable to connect)"
+    echo ""
+}


### PR DESCRIPTION
## Summary

Refactored `make deploy` to use layer-aware transfers instead of full tarball transfers. This significantly reduces deployment time by only transferring changed Docker layers via rsync, rather than compressing and copying all images every time.

## Problem

The previous deployment process:
1. `docker save` all 6 images into a single tarball
2. `gzip` compress (~550MB)
3. `scp` transfer to remote server
4. `gunzip | docker load` on remote

This transferred the entire ~550MB every deployment, even when only a few application layers changed.

## Solution

Use OCI directory format with rsync for incremental transfers:
1. `docker save | tar -x` to OCI directory (content-addressed blobs at `blobs/sha256/{hash}`)
2. `rsync --checksum` to transfer only changed blobs
3. `tar | docker load` on remote to load images

## Expected Improvements

| Scenario | Before | After |
|----------|--------|-------|
| Code-only change | ~550MB | ~25-35MB |
| Base image update | ~550MB | ~250-400MB (only changed layers) |
| First deploy | ~550MB | ~1.3GB (uncompressed, but one-time) |

## Changes

### New Files
- `scripts/layer-transfer.sh` - Layer-aware transfer functions:
  - `prepare_oci_directory()` - Extract images to OCI format
  - `transfer_oci_directory()` - rsync with checksum comparison
  - `load_images_remote()` - Load images from OCI directory
  - `cleanup_local_cache()` / `cleanup_remote_cache()` - Cache management

### Modified Files
- `scripts/common.sh` - Added cache directory constants
- `scripts/deploy.sh` - Replaced tarball transfer with `transfer_images()` call
- `Makefile` - Added cache management targets

### New Makefile Targets
```bash
make layer-cache-stats         # Show local and remote cache statistics
make layer-cache-clean         # Clean local OCI cache
make layer-cache-clean-remote  # Clean remote OCI cache
```

## Technical Details

### How rsync Deduplication Works

Docker's OCI format stores layers as content-addressed blobs:
```
blobs/sha256/a1b2c3d4...  # Base image layer (unchanged)
blobs/sha256/e5f6g7h8...  # App dependencies (unchanged)
blobs/sha256/i9j0k1l2...  # Application code (changed)
```

Since blob filenames are their SHA256 hash, rsync's `--checksum` flag efficiently skips unchanged files. Only new/modified blobs are transferred.

### Cache Structure

```
Local:  /tmp/beef-briefing-oci-cache/{commit-hash}/
Remote: ~/beef-briefing/.oci-cache/{commit-hash}/
```

Both local and remote caches keep the last 2 versions for rollback support.

## Test Plan

- [ ] First deploy (clean remote): Full transfer works
- [ ] Incremental deploy (code change only): Only app layers transfer (~25-35MB)
- [ ] `make layer-cache-stats`: Shows correct blob counts
- [ ] `make prod-rollback`: Still works with cached images
- [ ] `make layer-cache-clean`: Cleans local cache
- [ ] `make layer-cache-clean-remote`: Cleans remote cache
