### PR TITLE
Change Re-roll Mechanics

### DIFF
--- a/apps/api-service/internal/game/README.md
+++ b/apps/api-service/internal/game/README.md
@@ -28,7 +28,7 @@
 
 Beef Arena is a competitive card battle game where players:
 1. Join matches with other players
-2. Build teams of 3 cards from a random shop
+2. Build teams of 3 cards from a random shop (with optional rerolls before first purchase)
 3. Battle automatically using turn-based combat
 4. Earn rankings based on wins/losses
 
@@ -83,8 +83,8 @@ The game supports two modes:
   - Frontend can continue polling to detect when battle starts
   - No errors returned for post-submission requests
 - **Actions**:
-  - Buy cards from shop (6 cards available)
-  - Reroll shop for new cards
+  - **Reroll shop** (only before first card purchase) - Replace unpurchased cards with new ones
+  - Buy cards from shop (4-6 cards available depending on rerolls)
   - Upgrade purchased cards (ATK or HP)
   - Set team battle order
   - Submit team when ready
@@ -127,11 +127,15 @@ The game supports two modes:
 | Action | Cost | Constraint | Description |
 |--------|------|------------|-------------|
 | **Buy Card** | 2 coins | Team not full (< 3) | Purchase card from shop slot |
-| **Reroll Shop** | 1 coin | Must leave enough for team | Replace unpurchased cards with new ones |
+| **Reroll Shop** | 1 coin | No cards purchased yet | Replace unpurchased cards with new ones (only before first purchase) |
 | **Upgrade ATK** | 2 coins | Card in team | +1 ATK per upgrade |
 | **Upgrade HP** | 2 coins | Card in team | +3 HP per upgrade |
 
-**Important**: Reroll and upgrade actions validate that you'll have enough coins remaining to complete your 3-card team. *(Logic in [shop/types.go:48-82](shop/types.go#L48-L82))*
+**Important**:
+- **Reroll** is only available **before any card is purchased**. Once you buy your first card, the reroll button becomes permanently disabled for that match.
+- **Upgrade** actions validate that you'll have enough coins remaining to complete your 3-card team.
+
+*(Logic in [shop/types.go:48-82](shop/types.go#L48-L82))*
 
 #### Shop Card Selection
 - Cards are randomly selected from the current week's `ml_user_cards` for the chat
@@ -147,19 +151,23 @@ The game supports two modes:
 #### Building Your Team
 
 **Step-by-step**:
-1. **Buy 3 cards** from shop (required)
+1. **Review initial shop cards**
+   - You start with 4 random cards (6 total with rerolls)
+2. **Optional: Reroll** (only before first purchase)
+   - Costs 1 coin
+   - Replaces unpurchased cards with new ones
+   - **Once you buy your first card, reroll becomes permanently disabled**
+3. **Buy 3 cards** from shop (required)
    - Each purchase costs 2 coins
    - Choose wisely based on stats
-2. **Optional: Reroll** before buying if you don't like options
-   - Costs 1 coin
-   - Can reroll multiple times
-3. **Optional: Upgrade** purchased cards
+   - This is your only chance to reroll - decide before buying!
+4. **Optional: Upgrade** purchased cards
    - Choose ATK for more damage
    - Choose HP for more survivability
-4. **Set battle order** (positions 0, 1, 2)
+5. **Set battle order** (positions 0, 1, 2)
    - Position 0 = front (battles first)
    - Position 2 = back (battles last)
-5. **Submit team** to proceed to battle
+6. **Submit team** to proceed to battle
 
 ---
 
@@ -429,10 +437,13 @@ POST /api/v1/mini-app/arena/match/<match_id>/reroll
 ```
 
 **Requirements**:
-- Have enough coins for: reroll (1) + remaining team slots (2 each)
-- Example: With 1 card purchased, need 1 + (2 * 2) = 5 coins
+- Have 1+ coins
+- **No cards purchased yet** (team must be empty)
+- Once you buy your first card, reroll is permanently disabled for that match
 
 **Response**: Updated shop state with new unpurchased cards
+
+**Error**: Returns `400 Bad Request` if you've already purchased a card with message "cannot reroll after purchasing cards"
 
 *Handler: [arena_handler.go:533-560](../handlers/arena_handler.go#L533-L560)*
 
@@ -1110,8 +1121,10 @@ const updatedShop = await POST(`/api/v1/mini-app/arena/match/${matchId}/buy`, {
   card_index: 0
 });
 
-// Reroll shop
-const updatedShop = await POST(`/api/v1/mini-app/arena/match/${matchId}/reroll`);
+// Reroll shop (only available before first purchase)
+if (shop.team.length === 0 && shop.coins >= 1) {
+  const updatedShop = await POST(`/api/v1/mini-app/arena/match/${matchId}/reroll`);
+}
 
 // Upgrade card
 const updatedShop = await POST(`/api/v1/mini-app/arena/match/${matchId}/upgrade`, {
@@ -1208,9 +1221,11 @@ function canBuyCard(shop: ShopState, cardIndex: number): boolean {
 
 // Check if can reroll
 function canReroll(shop: ShopState): boolean {
-  const remainingCards = 3 - shop.team.length;
-  const coinsNeeded = 1 + (remainingCards * 2);
-  return shop.coins >= coinsNeeded;
+  // Reroll only available before any card is purchased
+  if (shop.team.length > 0) {
+    return false;
+  }
+  return shop.coins >= 1;
 }
 
 // Check if can upgrade

--- a/apps/api-service/internal/game/shop/errors.go
+++ b/apps/api-service/internal/game/shop/errors.go
@@ -4,7 +4,7 @@ import "errors"
 
 var (
 	ErrCannotBuy          = errors.New("cannot buy card: insufficient coins or team full")
-	ErrCannotReroll       = errors.New("cannot reroll: insufficient coins")
+	ErrCannotReroll       = errors.New("cannot reroll: cards already purchased or insufficient coins")
 	ErrCannotUpgrade      = errors.New("cannot upgrade: insufficient coins or invalid slot")
 	ErrInvalidUpgradeType = errors.New("invalid upgrade type: must be 'atk' or 'hp'")
 	ErrInvalidOrder       = errors.New("invalid team order")

--- a/apps/api-service/internal/game/shop/types.go
+++ b/apps/api-service/internal/game/shop/types.go
@@ -61,11 +61,13 @@ func (s *ShopState) CanBuy(cardIndex int) bool {
 	return true
 }
 
-// CanReroll checks if a reroll is possible while ensuring enough coins remain to complete the team
+// CanReroll checks if a reroll is possible. Rerolls are only allowed before any card is purchased.
 func (s *ShopState) CanReroll() bool {
-	remainingCards := TeamSize - len(s.Team)
-	coinsNeededForCards := remainingCards * CardCost
-	return s.Coins >= (RerollCost + coinsNeededForCards)
+	// Can only reroll if no cards purchased yet
+	if len(s.Team) > 0 {
+		return false
+	}
+	return s.Coins >= RerollCost
 }
 
 // CanUpgrade checks if an upgrade is possible while ensuring enough coins remain to complete the team

--- a/apps/api-service/internal/services/arena_service.go
+++ b/apps/api-service/internal/services/arena_service.go
@@ -583,7 +583,7 @@ func (s *ArenaService) computeShopAffordability(coins int, teamSize int, isReady
 	coinsNeededForCards := remainingCards * shop.CardCost
 
 	canBuy := coins >= shop.CardCost && teamSize < shop.TeamSize
-	canReroll := coins >= (shop.RerollCost + coinsNeededForCards)
+	canReroll := teamSize == 0 && coins >= shop.RerollCost
 	canUpgrade := coins >= (shop.UpgradeCost + coinsNeededForCards)
 	canSubmit := teamSize == shop.TeamSize && !isReady
 
@@ -605,8 +605,12 @@ func (s *ArenaService) computeShopAffordability(coins int, teamSize int, isReady
 	}
 
 	if !canReroll {
-		reason := fmt.Sprintf("need %d coins (%d reroll + %d to complete team)",
-			shop.RerollCost+coinsNeededForCards, shop.RerollCost, coinsNeededForCards)
+		var reason string
+		if teamSize > 0 {
+			reason = "cannot reroll after purchasing cards"
+		} else {
+			reason = fmt.Sprintf("need %d coins", shop.RerollCost)
+		}
 		aff.RerollDisabledReason = &reason
 	}
 


### PR DESCRIPTION
## Summary

Restricts the re-roll action to only be available before purchasing any cards from the shop. Previously, players could re-roll at any time during the shop phase as long as they had sufficient coins. This change makes the early shop decision more impactful and strategic.

## Changes

### Core Mechanic Change

**Before**: Re-roll available anytime if you had enough coins for the re-roll (1 coin) + remaining team slots (2 coins each)

**After**: Re-roll only available if team is empty (no cards purchased) and you have 1+ coin

This makes the shop phase more decisive:
- Players must decide upfront if they want to re-roll before committing to any purchase
- Once you buy your first card, the re-roll button becomes permanently disabled for that match
- Simplifies the coin economy check (removes the "do I have enough coins to complete my team?" constraint for re-rolls)

### Files Modified

1. **[README.md](apps/api-service/internal/game/README.md)**
   - Updated shop overview to explain the "optional rerolls before first purchase" mechanic
   - Added clear warning: "Once you buy your first card, the reroll button becomes permanently disabled"
   - Updated step-by-step guide with numbered flow showing when re-rolls can happen
   - Updated re-roll endpoint documentation with new requirements
   - Updated validation function examples to match new logic

2. **[shop/types.go](apps/api-service/internal/game/shop/types.go)**
   - Modified `CanReroll()` method: now checks if team is empty instead of checking remaining coin capacity
   - Simplified validation: `teamSize == 0 && coins >= 1` instead of complex coin calculation

3. **[shop/errors.go](apps/api-service/internal/game/shop/errors.go)**
   - Updated `ErrCannotReroll` message to reflect new constraint: "cannot reroll: cards already purchased or insufficient coins"

4. **[arena_service.go](apps/api-service/internal/services/arena_service.go)**
   - Updated `computeShopAffordability()` to match new re-roll logic
   - Changed reason message: shows "cannot reroll after purchasing cards" when team is not empty, or "need 1 coins" when low on coins

## Gameplay Impact

- **More strategic shop phase**: Players must make a single re-roll decision before committing to purchases
- **Simplified coin economy**: No need to reserve coins for "future re-rolls" when calculating purchases
- **Clearer progression**: Shop phase flow is: Review → Optional Re-roll → Buy 3 cards → Upgrade → Set Order → Submit

## Testing

- Verify re-roll button is available on initial shop screen with empty team
- Verify re-roll button becomes disabled after purchasing first card
- Verify re-roll costs 1 coin and replaces unpurchased cards
- Verify error message shows "cannot reroll after purchasing cards" when attempting to re-roll with non-empty team
- Verify re-roll works correctly even with multiple available coins

## Notes

- This is a gameplay balance change with no database schema modifications
- The error message has been updated to be clearer about the constraint
- Validation logic is now simpler and easier to understand for future maintenance
