### PR TITLE
 Compact Card Animation Adjustments

### DIFF
--- a/apps/arena-mini-app/src/hooks/useBattleAnimation.ts
+++ b/apps/arena-mini-app/src/hooks/useBattleAnimation.ts
@@ -326,6 +326,16 @@ export function useBattleAnimation(
         }
 
         case 'damage': {
+          // Debug logging to trace HP updates
+          console.log('[Battle Debug] Damage phase:', {
+            eventType: event.type,
+            defender_card_id: event.defender_card_id,
+            defender_team_owner_id: event.defender_team_owner_id,
+            hp_before: event.hp_before,
+            hp_after: event.hp_after,
+            damage: event.damage,
+          })
+
           // Update HP in card states (triggers HP bar animation via CSS transition)
           if (event.defender_card_id && event.defender_team_owner_id) {
             const defenderKey = getCardKey(
@@ -336,13 +346,36 @@ export function useBattleAnimation(
             setCardStates((prev: Map<string, CardSnapshot>) => {
               const next = new Map(prev)
               const defender = next.get(defenderKey)
-              if (defender && event.hp_after !== undefined) {
+
+              // Debug: log key lookup result
+              console.log('[Battle Debug] Key lookup:', {
+                defenderKey,
+                found: !!defender,
+                availableKeys: Array.from(prev.keys()),
+              })
+
+              // Calculate hp_after with fallback: prefer explicit value, else compute from hp_before - damage
+              const hpAfter =
+                event.hp_after ??
+                (event.hp_before !== undefined && event.damage !== undefined
+                  ? event.hp_before - event.damage
+                  : undefined)
+
+              console.log('[Battle Debug] HP calculation:', {
+                hp_after_from_event: event.hp_after,
+                hp_after_computed: hpAfter,
+                will_update: defender && hpAfter !== undefined,
+              })
+
+              if (defender && hpAfter !== undefined) {
                 // Clamp HP to 0 minimum - backend may send negative values for overkill damage
-                const clampedHp = Math.max(0, event.hp_after)
+                const clampedHp = Math.max(0, hpAfter)
+                // Only update HP here - is_alive will be set in 'complete' phase
+                // This ensures the card doesn't grey out while attack animation is still playing
                 next.set(defenderKey, {
                   ...defender,
                   hp: clampedHp,
-                  is_alive: clampedHp > 0,
+                  // Keep is_alive unchanged for now - will be updated in complete phase
                 })
               }
               return next
@@ -362,6 +395,27 @@ export function useBattleAnimation(
         }
 
         case 'complete': {
+          // Update is_alive state for any cards that died during this event
+          // This is done AFTER animations complete so the card doesn't grey out mid-attack
+          if (event.defender_card_id && event.defender_team_owner_id) {
+            const defenderKey = getCardKey(
+              event.defender_team_owner_id,
+              event.defender_card_id
+            )
+            setCardStates((prev: Map<string, CardSnapshot>) => {
+              const next = new Map(prev)
+              const defender = next.get(defenderKey)
+              if (defender) {
+                // Now set is_alive based on current HP
+                next.set(defenderKey, {
+                  ...defender,
+                  is_alive: defender.hp > 0,
+                })
+              }
+              return next
+            })
+          }
+
           // Clear animation states back to idle
           clearAnimationStates()
 
@@ -501,10 +555,17 @@ export function useBattleAnimation(
         const defender = finalCardStates.get(defenderKey)
 
         if (defender) {
+          // Calculate hp_after with fallback: prefer explicit value, else compute from hp_before - damage
+          const hpAfter =
+            event.hp_after ??
+            (event.hp_before !== undefined && event.damage !== undefined
+              ? event.hp_before - event.damage
+              : undefined)
+
           // Update HP and is_alive
-          if (event.hp_after !== undefined) {
+          if (hpAfter !== undefined) {
             // Clamp HP to 0 minimum - backend may send negative values for overkill damage
-            const clampedHp = Math.max(0, event.hp_after)
+            const clampedHp = Math.max(0, hpAfter)
             finalCardStates.set(defenderKey, {
               ...defender,
               hp: clampedHp,

--- a/apps/arena-mini-app/src/styles/global.css
+++ b/apps/arena-mini-app/src/styles/global.css
@@ -581,7 +581,7 @@ a:focus:not(:focus-visible),
 }
 
 /* Taking damage state - red glow with shake effect */
-.compact-card-anim-taking-damage {
+.compact-card-anim-taking_damage {
   --anim-scale: 1;
   animation: card-damage-shake 0.3s ease-in-out;
   box-shadow:


### PR DESCRIPTION
## Summary

Fixed battle animation state management to properly handle HP updates and card lifecycle state. Separated HP damage updates from alive/dead state transitions to prevent premature card greyout animations. Enhanced debugging capabilities with detailed logging of state updates.

## Changes

### 1. **Battle Animation Hook** (`apps/arena-mini-app/src/hooks/useBattleAnimation.ts`)

#### Debug Logging
- Added comprehensive debug logging throughout damage event processing to trace:
  - Event details (defender card ID, team owner, HP values, damage amounts)
  - Card key lookups and available keys for troubleshooting state mismatches
  - HP calculation logic and state update decisions

#### HP Update Logic Improvements
- **Fallback HP calculation**: Now computes `hp_after` from `hp_before - damage` when explicit `hp_after` is not provided by the backend
  ```typescript
  const hpAfter = event.hp_after ??
    (event.hp_before !== undefined && event.damage !== undefined
      ? event.hp_before - event.damage
      : undefined)
  ```
- **Overkill damage handling**: Maintains clamping to 0 minimum for negative HP values (backend may send negative for overkill)

#### Animation Phase Separation
- **Damage phase**: Updates only HP value, keeping `is_alive` unchanged
  - Prevents card from greying out while attack animation is still playing
  - Allows damage animation to complete visually before state change

- **Complete phase**: Updates `is_alive` state based on current HP
  - Only transitions dead cards to grey state after all animations finish
  - Ensures smooth UX without premature visual feedback

#### Implementation Details
- Damage phase: Sets HP only
  ```typescript
  next.set(defenderKey, {
    ...defender,
    hp: clampedHp,
    // Keep is_alive unchanged for now - will be updated in complete phase
  })
  ```

- Complete phase: Updates is_alive
  ```typescript
  next.set(defenderKey, {
    ...defender,
    is_alive: defender.hp > 0,
  })
  ```

### 2. **CSS Class Name Fix** (`apps/arena-mini-app/src/styles/global.css`)

- Fixed animation class name: `compact-card-anim-taking-damage` → `compact-card-anim-taking_damage`
- Uses underscore instead of hyphen to match JavaScript class naming conventions and prevent selector mismatches

## Impact

- **Visual Polish**: Card death animations now complete smoothly without premature state transitions
- **Robustness**: Fallback HP calculation handles backend variations in event data format
- **Debuggability**: Enhanced logging helps identify state synchronization issues during battle
- **Consistency**: CSS class naming now aligns with JavaScript conventions

## Testing Recommendations

1. **HP Updates**: Monitor browser console logs during battle to verify HP calculations
2. **Card Greyout**: Verify cards don't grey out until after attack animations complete
3. **Overkill Damage**: Test with damage exceeding remaining HP to ensure HP clamps to 0
4. **State Consistency**: Check available keys vs looked-up keys in debug logs for any mismatches
5. **Performance**: Verify debug logging doesn't impact animation performance (can be removed/disabled later)

## Notes

- Debug logging uses `console.log` with `[Battle Debug]` prefix for easy filtering
- Can be replaced with proper logging infrastructure or conditional debugging in future
- HP calculation fallback is defensive; backend should ideally always provide explicit `hp_after`
- Animation phase separation is non-breaking and improves UX without changing API contract

## Related Issues

- Fixes premature card greyout during battle animations
- Improves robustness of HP state management for edge cases
