### PR TITLE
User Profile Photos in Arena Mini App

### DIFF
--- a/apps/api-service/internal/repository/game_repo.go
+++ b/apps/api-service/internal/repository/game_repo.go
@@ -222,8 +222,10 @@ type Participant struct {
 // ParticipantWithUser includes user info
 type ParticipantWithUser struct {
 	Participant
-	FirstName string `json:"first_name"`
-	Username  string `json:"username,omitempty"`
+	FirstName      string  `json:"first_name"`
+	Username       string  `json:"username,omitempty"`
+	PhotoObjectKey *string `json:"-"`                      // Internal: minio object key (not serialized)
+	PhotoURL       *string `json:"photo_url,omitempty"`    // Presigned URL for profile photo
 }
 
 // MatchRound represents a battle round
@@ -265,8 +267,10 @@ type LeaderboardEntry struct {
 	FirstMatchAt            *time.Time      `json:"first_match_at,omitempty"`
 	LastMatchAt             *time.Time      `json:"last_match_at,omitempty"`
 	// User info from join
-	FirstName string `json:"first_name,omitempty"`
-	Username  string `json:"username,omitempty"`
+	FirstName      string  `json:"first_name,omitempty"`
+	Username       string  `json:"username,omitempty"`
+	PhotoObjectKey *string `json:"-"`                   // Internal: minio object key (not serialized)
+	PhotoURL       *string `json:"photo_url,omitempty"` // Presigned URL for profile photo
 }
 
 // RankedTournament represents a daily ranked tournament

--- a/apps/api-service/internal/repository/match_repo.go
+++ b/apps/api-service/internal/repository/match_repo.go
@@ -285,7 +285,8 @@ func (r *MatchRepository) GetLeaderboard(ctx context.Context, chatID int64, matc
 		       l.regular_wins, l.regular_losses, l.regular_draws, l.regular_matches_played,
 		       l.regular_current_streak, l.regular_best_streak,
 		       l.head_to_head, l.first_match_at, l.last_match_at,
-		       u.first_name, COALESCE(u.username, '')
+		       u.first_name, COALESCE(u.username, ''),
+		       (SELECT minio_object_key FROM user_profile_photos WHERE user_id = l.user_id ORDER BY width DESC LIMIT 1)
 		FROM game_leaderboard l
 		JOIN users u ON l.user_id = u.id
 		WHERE l.chat_id = $1
@@ -309,7 +310,7 @@ func (r *MatchRepository) GetLeaderboard(ctx context.Context, chatID int64, matc
 			&e.RegularWins, &e.RegularLosses, &e.RegularDraws, &e.RegularMatchesPlayed,
 			&e.RegularCurrentStreak, &e.RegularBestStreak,
 			&e.HeadToHead, &e.FirstMatchAt, &e.LastMatchAt,
-			&e.FirstName, &e.Username,
+			&e.FirstName, &e.Username, &e.PhotoObjectKey,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan leaderboard row: %w", err)

--- a/apps/api-service/internal/repository/participant_repo.go
+++ b/apps/api-service/internal/repository/participant_repo.go
@@ -83,7 +83,8 @@ func (r *ParticipantRepository) GetMatchParticipants(ctx context.Context, matchI
 		SELECT p.id, p.match_id, p.user_id, p.status, p.joined_at, p.coins_remaining,
 		       p.shop_cards, p.team, p.team_order, p.team_submitted_at,
 		       p.placement, p.wins, p.losses, p.total_damage_dealt,
-		       u.first_name, COALESCE(u.username, '')
+		       u.first_name, COALESCE(u.username, ''),
+		       (SELECT minio_object_key FROM user_profile_photos WHERE user_id = u.id ORDER BY width DESC LIMIT 1)
 		FROM game_match_participants p
 		JOIN users u ON p.user_id = u.id
 		WHERE p.match_id = $1
@@ -103,7 +104,7 @@ func (r *ParticipantRepository) GetMatchParticipants(ctx context.Context, matchI
 			&p.ID, &p.MatchID, &p.UserID, &p.Status, &p.JoinedAt,
 			&p.CoinsRemaining, &p.ShopCards, &p.Team, &p.TeamOrder,
 			&p.TeamSubmittedAt, &p.Placement, &p.Wins, &p.Losses, &p.TotalDamageDealt,
-			&p.FirstName, &p.Username,
+			&p.FirstName, &p.Username, &p.PhotoObjectKey,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan participant row: %w", err)

--- a/apps/api-service/internal/services/arena_service.go
+++ b/apps/api-service/internal/services/arena_service.go
@@ -226,6 +226,9 @@ func (s *ArenaService) CreateMatch(ctx context.Context, chatID int64, creatorUse
 		return nil, fmt.Errorf("failed to get participants: %w", err)
 	}
 
+	// Populate photo URLs
+	s.populateParticipantPhotoURLs(ctx, participants)
+
 	// Record match creation metric
 	recordMatchEvent(s.nrApp, "created", match.ID, chatID, creatorUserID, string(repository.MatchTypeRegular))
 
@@ -253,6 +256,9 @@ func (s *ArenaService) GetMatch(ctx context.Context, matchID string) (*MatchResp
 		return nil, fmt.Errorf("failed to get participants: %w", err)
 	}
 
+	// Populate photo URLs
+	s.populateParticipantPhotoURLs(ctx, participants)
+
 	cardCount, _ := s.dealer.GetCardCount(ctx, match.ChatID)
 
 	return &MatchResponse{
@@ -277,6 +283,8 @@ func (s *ArenaService) GetActiveMatches(ctx context.Context, chatID int64) ([]*M
 		if err != nil {
 			continue // Skip on error
 		}
+		// Populate photo URLs
+		s.populateParticipantPhotoURLs(ctx, participants)
 		responses = append(responses, &MatchResponse{
 			Match:        match,
 			Participants: participants,
@@ -431,7 +439,15 @@ func (s *ArenaService) GetLeaderboard(ctx context.Context, chatID int64, matchTy
 	if matchType == "regular" {
 		mt = repository.MatchTypeRegular
 	}
-	return s.gameRepo.GetLeaderboard(ctx, chatID, mt, limit, offset)
+	entries, err := s.gameRepo.GetLeaderboard(ctx, chatID, mt, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	// Populate photo URLs
+	s.populateLeaderboardPhotoURLs(ctx, entries)
+
+	return entries, nil
 }
 
 // =============================================================================
@@ -795,4 +811,26 @@ func (s *ArenaService) GetPhotoPresignedURL(ctx context.Context, objectKey strin
 		return "", nil
 	}
 	return s.storageClient.GetPresignedURL(ctx, objectKey, 24*time.Hour)
+}
+
+// populateParticipantPhotoURLs generates presigned URLs for participant photos
+func (s *ArenaService) populateParticipantPhotoURLs(ctx context.Context, participants []*repository.ParticipantWithUser) {
+	for _, p := range participants {
+		if p.PhotoObjectKey != nil && *p.PhotoObjectKey != "" {
+			if url, err := s.storageClient.GetPresignedURL(ctx, *p.PhotoObjectKey, time.Hour); err == nil && url != "" {
+				p.PhotoURL = &url
+			}
+		}
+	}
+}
+
+// populateLeaderboardPhotoURLs generates presigned URLs for leaderboard entry photos
+func (s *ArenaService) populateLeaderboardPhotoURLs(ctx context.Context, entries []*repository.LeaderboardEntry) {
+	for _, e := range entries {
+		if e.PhotoObjectKey != nil && *e.PhotoObjectKey != "" {
+			if url, err := s.storageClient.GetPresignedURL(ctx, *e.PhotoObjectKey, time.Hour); err == nil && url != "" {
+				e.PhotoURL = &url
+			}
+		}
+	}
 }

--- a/apps/arena-mini-app/src/components/lobby/LobbyPage.tsx
+++ b/apps/arena-mini-app/src/components/lobby/LobbyPage.tsx
@@ -12,6 +12,7 @@ import { useState, useCallback, useRef } from 'react'
 
 import { apiClient } from '../../api/client'
 import { addPageAction, noticeError } from '@beef-briefing/shared-mini-app/monitoring'
+import { Avatar } from '@beef-briefing/shared-mini-app/components'
 import { LoadingSpinner, CountdownTimer, ErrorBanner } from '../common'
 import { GameButton, RPGPanel } from '../ui'
 import { usePolling, useErrorBanner } from '../../hooks'
@@ -424,17 +425,17 @@ export function LobbyPage({
                   {activeMatch.participants?.map((p) => (
                     <div
                       key={p.user_id}
-                      className={`participant-chip ${p.user_id === userId ? 'is-you' : ''}`}
-                      title={p.username || p.first_name}
+                      className={`participant-avatar ${p.user_id === userId ? 'is-you' : ''} ${p.user_id === activeMatch.creator_user_id ? 'is-creator' : ''}`}
+                      title={p.username ? `${p.first_name} (@${p.username})` : p.first_name}
                     >
-                      <span className="participant-name">
-                        {p.first_name}
-                        {p.user_id === activeMatch.creator_user_id && (
-                          <span className="participant-creator-badge" title="Match creator">
-                            👑
-                          </span>
-                        )}
-                      </span>
+                      <Avatar
+                        firstName={p.first_name}
+                        photoUrl={p.photo_url}
+                        size="small"
+                      />
+                      {p.user_id === activeMatch.creator_user_id && (
+                        <span className="creator-crown" title="Match creator">👑</span>
+                      )}
                     </div>
                   ))}
                 </div>
@@ -558,17 +559,17 @@ export function LobbyPage({
                               {match.participants?.map((p) => (
                                 <div
                                   key={p.user_id}
-                                  className={`participant-chip ${p.user_id === userId ? 'is-you' : ''}`}
-                                  title={p.username || p.first_name}
+                                  className={`participant-avatar ${p.user_id === userId ? 'is-you' : ''} ${p.user_id === match.creator_user_id ? 'is-creator' : ''}`}
+                                  title={p.username ? `${p.first_name} (@${p.username})` : p.first_name}
                                 >
-                                  <span className="participant-name">
-                                    {p.first_name}
-                                    {p.user_id === match.creator_user_id && (
-                                      <span className="participant-creator-badge" title="Match creator">
-                                        👑
-                                      </span>
-                                    )}
-                                  </span>
+                                  <Avatar
+                                    firstName={p.first_name}
+                                    photoUrl={p.photo_url}
+                                    size="small"
+                                  />
+                                  {p.user_id === match.creator_user_id && (
+                                    <span className="creator-crown" title="Match creator">👑</span>
+                                  )}
                                 </div>
                               ))}
                             </div>

--- a/apps/arena-mini-app/src/components/stats/StatsPage.tsx
+++ b/apps/arena-mini-app/src/components/stats/StatsPage.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 
 import { apiClient } from '../../api/client'
 import { addPageAction, noticeError } from '@beef-briefing/shared-mini-app/monitoring'
+import { Avatar } from '@beef-briefing/shared-mini-app/components'
 import { LoadingSpinner } from '../common'
 import { RPGPanel, GameButton } from '../ui'
 
@@ -370,6 +371,11 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
                   <div className={`rpg-rank-badge ${getRankClass(entry.rank)}`}>
                     <span className="rpg-rank-number">{entry.rank}</span>
                   </div>
+                  <Avatar
+                    firstName={entry.first_name}
+                    photoUrl={entry.photo_url}
+                    size="small"
+                  />
                   <div className="rpg-leaderboard-user">
                     <div className="rpg-leaderboard-name">
                       {entry.first_name}
@@ -626,6 +632,11 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
                       {match.result === 'win' ? 'W' : match.result === 'loss' ? 'L' : 'D'}
                     </span>
                   </div>
+                  <Avatar
+                    firstName={match.opponent.first_name}
+                    photoUrl={match.opponent.photo_url}
+                    size="small"
+                  />
                   <div className="rpg-history-details">
                     <div className="rpg-history-opponent">vs {match.opponent.first_name}</div>
                     <div className="rpg-history-meta">

--- a/apps/arena-mini-app/src/styles/global.css
+++ b/apps/arena-mini-app/src/styles/global.css
@@ -6482,3 +6482,109 @@ button,
   letter-spacing: 0.1em;
   text-shadow: 0 0 20px rgba(249, 115, 22, 0.4);
 }
+
+/* =============================================================================
+   Avatar Integration Styles (shared-mini-app Avatar component)
+   ============================================================================= */
+
+/* Lobby participant avatars - avatar-only display */
+.participant-avatar {
+  position: relative;
+  display: inline-block;
+}
+
+.participant-avatar .avatar {
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  font-size: 12px;
+  border: 2px solid rgba(90, 74, 58, 0.4);
+  border-radius: 50%;
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.participant-avatar:hover .avatar {
+  transform: scale(1.1);
+}
+
+.participant-avatar.is-you .avatar {
+  border-color: var(--arena-orange, #f97316);
+  box-shadow: 0 0 8px rgba(249, 115, 22, 0.4);
+}
+
+.participant-avatar.is-creator .avatar {
+  border-color: #ffd700;
+}
+
+/* Creator crown badge */
+.participant-avatar .creator-crown {
+  position: absolute;
+  top: -6px;
+  right: -4px;
+  font-size: 12px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+  pointer-events: none;
+}
+
+/* Update participants-list for avatar-only layout */
+.participants-list {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* Leaderboard avatars */
+.rpg-leaderboard-item .avatar {
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  font-size: 11px;
+  margin-right: 8px;
+  border: 2px solid rgba(90, 74, 58, 0.3);
+  flex-shrink: 0;
+}
+
+.rpg-leaderboard-item.current-user .avatar {
+  border-color: var(--arena-orange, #f97316);
+}
+
+/* Rank-specific avatar borders for top 3 */
+.rpg-leaderboard-item:has(.rpg-rank-badge.gold) .avatar {
+  border-color: #ffd700;
+  box-shadow: 0 0 8px rgba(255, 215, 0, 0.4);
+}
+
+.rpg-leaderboard-item:has(.rpg-rank-badge.silver) .avatar {
+  border-color: #c0c0c0;
+  box-shadow: 0 0 6px rgba(192, 192, 192, 0.4);
+}
+
+.rpg-leaderboard-item:has(.rpg-rank-badge.bronze) .avatar {
+  border-color: #cd7f32;
+  box-shadow: 0 0 6px rgba(205, 127, 50, 0.4);
+}
+
+/* History avatars */
+.rpg-history-item .avatar {
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  font-size: 11px;
+  margin-right: 8px;
+  border: 2px solid rgba(90, 74, 58, 0.3);
+  flex-shrink: 0;
+}
+
+/* Result-specific avatar borders */
+.rpg-history-item.result-win .avatar {
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.rpg-history-item.result-loss .avatar {
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+.rpg-history-item.result-draw .avatar {
+  border-color: rgba(234, 179, 8, 0.5);
+}

--- a/apps/arena-mini-app/src/types/index.ts
+++ b/apps/arena-mini-app/src/types/index.ts
@@ -168,6 +168,8 @@ export interface Participant {
   first_name: string
   /** User's Telegram username (optional) */
   username?: string
+  /** Presigned URL for user's profile photo */
+  photo_url?: string
 }
 
 /**


### PR DESCRIPTION
# User Profile Photos in Arena Mini App

## Summary

This PR adds user profile photo support to the Arena Mini App, displaying avatars for participants in the lobby, leaderboard entries, and match history.

## Changes

### Backend (Go)

**Repository Layer:**
- Added `PhotoObjectKey` and `PhotoURL` fields to `ParticipantWithUser` and `LeaderboardEntry` structs in [game_repo.go](apps/api-service/internal/repository/game_repo.go)
- Updated `GetMatchParticipants` query to fetch profile photo from `user_profile_photos` table in [participant_repo.go](apps/api-service/internal/repository/participant_repo.go)
- Updated `GetLeaderboard` query to include profile photo lookup in [match_repo.go](apps/api-service/internal/repository/match_repo.go)

**Service Layer:**
- Added `populateParticipantPhotoURLs()` helper to generate presigned URLs for participant photos
- Added `populateLeaderboardPhotoURLs()` helper for leaderboard entry photos
- Integrated photo URL population into `CreateMatch`, `GetMatch`, `GetActiveMatches`, and `GetLeaderboard` endpoints in [arena_service.go](apps/api-service/internal/services/arena_service.go)

### Frontend (React/TypeScript)

**Components:**
- [LobbyPage.tsx](apps/arena-mini-app/src/components/lobby/LobbyPage.tsx): Replaced text-based participant chips with `Avatar` components from shared-mini-app, showing profile photos or initials as fallback
- [StatsPage.tsx](apps/arena-mini-app/src/components/stats/StatsPage.tsx): Added `Avatar` components to leaderboard items and match history entries

**Types:**
- Added `photo_url` field to `Participant` interface in [types/index.ts](apps/arena-mini-app/src/types/index.ts)

**Styles:**
- Added avatar integration styles in [global.css](apps/arena-mini-app/src/styles/global.css):
  - Lobby participant avatars with hover effects and "is-you" highlighting
  - Creator crown badge positioning
  - Leaderboard avatars with rank-specific borders (gold/silver/bronze)
  - Match history avatars with result-specific borders (win/loss/draw)

## API Response Changes

The following endpoints now include `photo_url` in their responses:

- `GET /api/v1/mini-app/arena/matches` - participant photo URLs
- `GET /api/v1/mini-app/arena/match/{id}` - participant photo URLs
- `POST /api/v1/mini-app/arena/matches` - participant photo URLs in response
- `GET /api/v1/mini-app/arena/leaderboard` - entry photo URLs

Photo URLs are presigned with 1-hour expiry for participants and leaderboard entries.

## Test Plan

- [ ] Create a match and verify participant avatars display in lobby
- [ ] Join a match and verify your avatar has orange border highlight
- [ ] Verify creator crown badge appears correctly on avatar
- [ ] Check leaderboard displays avatars with rank-specific styling (gold/silver/bronze borders)
- [ ] Check match history shows opponent avatars with result-colored borders
- [ ] Verify fallback to initials when no profile photo exists
- [ ] Test hover effects on participant avatars
