### PR TITLE
Refactor Battle Playback Controls to Tab Bar

### DIFF
--- a/apps/arena-mini-app/src/App.tsx
+++ b/apps/arena-mini-app/src/App.tsx
@@ -9,6 +9,7 @@ import { TabBar, SplashScreen, ErrorDisplay, LoadingSpinner } from './components
 import { SoundProvider } from './contexts'
 
 import type { TabId, AppState, GameConstants, Match } from './types'
+import type { BattlePlaybackProps } from './components/common'
 
 // Lazy load page components for code splitting
 // Each page will be loaded in a separate chunk when first accessed
@@ -34,6 +35,10 @@ function App() {
   // Game state
   const [activeMatch, setActiveMatch] = useState<Match | null>(null)
   const [gameConstants, setGameConstants] = useState<GameConstants | null>(null)
+
+  // Battle playback state (lifted for TabBar access)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [speedIndex, setSpeedIndex] = useState(0) // 0=1x, 1=1.5x, 2=2x
 
   // Get launch params from Telegram
   let launchParams: ReturnType<typeof useLaunchParams> | null = null
@@ -179,6 +184,31 @@ function App() {
     handleTabChange('battle')
   }, [handleTabChange])
 
+  // Battle playback callbacks for TabBar
+  const handlePlayPause = useCallback(() => {
+    setIsPlaying((prev) => !prev)
+  }, [])
+
+  const handleCycleSpeed = useCallback(() => {
+    setSpeedIndex((prev) => (prev + 1) % 3)
+  }, [])
+
+  // Sync isPlaying state from BattlePage
+  const handlePlayingChange = useCallback((playing: boolean) => {
+    setIsPlaying(playing)
+  }, [])
+
+  // Battle playback props for TabBar (only shown during battle tab)
+  const battlePlayback: BattlePlaybackProps | undefined =
+    activeTab === 'battle'
+      ? {
+          isPlaying,
+          onPlayPause: handlePlayPause,
+          speedIndex,
+          onCycleSpeed: handleCycleSpeed,
+        }
+      : undefined
+
   // Render page based on active tab
   const renderPage = () => {
     switch (activeTab) {
@@ -213,6 +243,9 @@ function App() {
             onMatchChange={handleMatchChange}
             onNavigateToStats={() => handleTabChange('stats')}
             onNavigateToLobby={navigateToLobby}
+            isPlaying={isPlaying}
+            onPlayingChange={handlePlayingChange}
+            speedIndex={speedIndex}
           />
         )
       case 'stats':
@@ -280,7 +313,7 @@ function App() {
             </Suspense>
           </ErrorBoundary>
         </main>
-        <TabBar activeTab={activeTab} onTabChange={handleTabChange} />
+        <TabBar activeTab={activeTab} onTabChange={handleTabChange} battlePlayback={battlePlayback} />
       </div>
     </SoundProvider>
   )

--- a/apps/arena-mini-app/src/components/battle/BattlePage.tsx
+++ b/apps/arena-mini-app/src/components/battle/BattlePage.tsx
@@ -30,8 +30,8 @@ import type {
 } from '../../types'
 
 // Playback speed options (events per second)
+// Index: 0=1x, 1=1.5x, 2=2x (controlled by parent via speedIndex prop)
 const PLAYBACK_SPEEDS = [
-  { label: '0.5x', value: 2000 },
   { label: '1x', value: 1000 },
   { label: '1.5x', value: 667 },
   { label: '2x', value: 500 },
@@ -44,6 +44,12 @@ interface BattlePageProps {
   onNavigateToStats?: () => void
   onNavigateToLobby?: () => void
   onMatchChange?: (match: Match | null) => void
+  /** Playback state from parent (for TabBar sync) */
+  isPlaying: boolean
+  /** Callback to notify parent of playing state changes */
+  onPlayingChange: (playing: boolean) => void
+  /** Speed index from parent (0=1x, 1=1.5x, 2=2x) */
+  speedIndex: number
 }
 
 export function BattlePage({
@@ -53,14 +59,14 @@ export function BattlePage({
   onNavigateToStats,
   onNavigateToLobby,
   onMatchChange,
+  isPlaying: parentIsPlaying,
+  onPlayingChange,
+  speedIndex,
 }: BattlePageProps) {
   // Battle data state
   const [battleData, setBattleData] = useState<BattleResult | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-
-  // Playback speed UI state (index into PLAYBACK_SPEEDS array)
-  const [playbackSpeedIndex, setPlaybackSpeedIndex] = useState(1) // Default to 1x
 
   // Victory screen state (separate from animation completion for UI control)
   const [showVictory, setShowVictory] = useState(false)
@@ -101,7 +107,7 @@ export function BattlePage({
     animationStates,
     currentEventIndex,
     currentPhase,
-    isPlaying,
+    isPlaying: hookIsPlaying,
     isComplete,
     currentDamage,
     damageTargetKey,
@@ -110,15 +116,28 @@ export function BattlePage({
     play,
     pause,
     reset,
-    skipToEnd: hookSkipToEnd,
   } = useBattleAnimation(battleData, {
     // Convert interval-based speed to multiplier (1000ms = 1x, 500ms = 2x)
-    playbackSpeed: 1000 / PLAYBACK_SPEEDS[playbackSpeedIndex].value,
+    playbackSpeed: 1000 / PLAYBACK_SPEEDS[speedIndex].value,
     playerAId: battleData?.player_a_id ?? 0,
     playerBId: battleData?.player_b_id ?? 0,
     onPlaySound: playSound,
     getCardPosition,
   })
+
+  // Sync parent isPlaying state with hook
+  useEffect(() => {
+    if (parentIsPlaying && !hookIsPlaying && !isComplete) {
+      play()
+    } else if (!parentIsPlaying && hookIsPlaying) {
+      pause()
+    }
+  }, [parentIsPlaying, hookIsPlaying, isComplete, play, pause])
+
+  // Notify parent when hook playing state changes
+  useEffect(() => {
+    onPlayingChange(hookIsPlaying)
+  }, [hookIsPlaying, onPlayingChange])
 
   // Get match ID
   const matchId = activeMatch?.id
@@ -179,15 +198,16 @@ export function BattlePage({
 
   // Auto-play battle after initial load
   useEffect(() => {
-    if (battleData && currentEventIndex === -1 && !isPlaying && !isComplete) {
+    if (battleData && currentEventIndex === -1 && !hookIsPlaying && !isComplete) {
       const autoPlayTimer = setTimeout(() => {
         play()
+        onPlayingChange(true)
         addPageAction('battle_autoplay_started', { match_id: matchId })
       }, 1500) // 1.5 second delay
 
       return () => clearTimeout(autoPlayTimer)
     }
-  }, [battleData, currentEventIndex, isPlaying, isComplete, matchId, play])
+  }, [battleData, currentEventIndex, hookIsPlaying, isComplete, matchId, play, onPlayingChange])
 
   // Show victory screen when animation completes and play win/lose/draw sound
   useEffect(() => {
@@ -207,22 +227,6 @@ export function BattlePage({
       }
     }
   }, [isComplete, showVictory, matchId, battleData, userId, playSound])
-
-  // Handle play/pause toggle
-  const togglePlayback = useCallback(() => {
-    if (isPlaying) {
-      pause()
-    } else {
-      play()
-    }
-  }, [isPlaying, play, pause])
-
-  // Skip to end wrapper (shows victory screen)
-  const skipToEnd = useCallback(() => {
-    hookSkipToEnd()
-    setShowVictory(true)
-    addPageAction('battle_skipped_to_end', { match_id: matchId })
-  }, [hookSkipToEnd, matchId])
 
   // Reset playback wrapper (hides victory screen)
   const resetPlayback = useCallback(() => {
@@ -372,7 +376,7 @@ export function BattlePage({
         style={{
           // Scale HP bar transition duration with playback speed
           // At 1x (value=1000), duration is 300ms; at 2x (value=500), duration is 150ms
-          '--hp-transition-duration': `${(PLAYBACK_SPEEDS[playbackSpeedIndex].value / 1000) * 300}ms`,
+          '--hp-transition-duration': `${(PLAYBACK_SPEEDS[speedIndex].value / 1000) * 300}ms`,
         } as React.CSSProperties}
       >
         {/* Team A (opponent or self) */}
@@ -408,59 +412,6 @@ export function BattlePage({
             size={80}
           />
         ))}
-      </div>
-
-      {/* Playback Controls */}
-      <div className="battle-controls rpg-battle-controls">
-        <GameButton
-          variant="neutral"
-          size="sm"
-          onClick={resetPlayback}
-          disabled={currentEventIndex < 0}
-          title="Reset"
-          className="control-btn"
-        >
-          ⏮️
-        </GameButton>
-
-        <GameButton
-          variant="primary"
-          size="sm"
-          onClick={togglePlayback}
-          title={isPlaying ? 'Pause' : 'Play'}
-          className={`control-btn play-btn ${isPlaying ? 'playing' : ''}`}
-        >
-          {isPlaying ? '⏸️' : '▶️'}
-        </GameButton>
-
-        <GameButton
-          variant="neutral"
-          size="sm"
-          onClick={skipToEnd}
-          disabled={currentEventIndex >= battleData.events.length - 1}
-          title="Skip to end"
-          className="control-btn"
-        >
-          ⏭️
-        </GameButton>
-
-        {/* Speed selector */}
-        <div className="speed-selector">
-          {PLAYBACK_SPEEDS.map((speed, index) => (
-            <button
-              key={speed.label}
-              className={`speed-btn ${index === playbackSpeedIndex ? 'active' : ''}`}
-              onClick={() => setPlaybackSpeedIndex(index)}
-            >
-              {speed.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Event counter */}
-        <div className="event-counter">
-          {currentEventIndex + 1} / {battleData.events.length}
-        </div>
       </div>
 
       {/* Event Log */}

--- a/apps/arena-mini-app/src/components/common/PlaybackControls.tsx
+++ b/apps/arena-mini-app/src/components/common/PlaybackControls.tsx
@@ -1,0 +1,93 @@
+/**
+ * Playback Controls Component
+ *
+ * Compact playback controls for the tab bar during battle:
+ * - Play/Pause button with SVG icons
+ * - Speed button cycling 1x → 1.5x → 2x
+ */
+
+import { GameButton } from '../ui/GameButton'
+
+/** SVG Play icon - triangle pointing right */
+const PlayIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    stroke="none"
+  >
+    <polygon points="5,3 19,12 5,21" />
+  </svg>
+)
+
+/** SVG Pause icon - two vertical bars */
+const PauseIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    stroke="none"
+  >
+    <rect x="5" y="4" width="4" height="16" rx="1" />
+    <rect x="15" y="4" width="4" height="16" rx="1" />
+  </svg>
+)
+
+/** Speed labels for each index */
+const SPEED_LABELS = ['1x', '1.5x', '2x']
+
+export interface PlaybackControlsProps {
+  /** Whether playback is currently playing */
+  isPlaying: boolean
+  /** Callback when play/pause is toggled */
+  onPlayPause: () => void
+  /** Current speed index (0=1x, 1=1.5x, 2=2x) */
+  speedIndex: number
+  /** Callback to cycle to next speed */
+  onCycleSpeed: () => void
+}
+
+/**
+ * Compact playback controls for the tab bar.
+ * Displayed during battle phase only.
+ */
+export function PlaybackControls({
+  isPlaying,
+  onPlayPause,
+  speedIndex,
+  onCycleSpeed,
+}: PlaybackControlsProps) {
+  return (
+    <div className="playback-controls">
+      <GameButton
+        variant={isPlaying ? 'secondary' : 'primary'}
+        shape="square"
+        size="lg"
+        className="tab-item-game playback-btn"
+        onClick={onPlayPause}
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+      >
+        <span className="tab-icon">
+          {isPlaying ? <PauseIcon /> : <PlayIcon />}
+        </span>
+        <span className="tab-label">{isPlaying ? 'Pause' : 'Play'}</span>
+      </GameButton>
+
+      <GameButton
+        variant="neutral"
+        shape="square"
+        size="lg"
+        className="tab-item-game playback-btn"
+        onClick={onCycleSpeed}
+        aria-label={`Speed: ${SPEED_LABELS[speedIndex]}`}
+      >
+        <span className="tab-icon speed-icon">{SPEED_LABELS[speedIndex]}</span>
+        <span className="tab-label">Speed</span>
+      </GameButton>
+    </div>
+  )
+}
+
+export default PlaybackControls

--- a/apps/arena-mini-app/src/components/common/TabBar.tsx
+++ b/apps/arena-mini-app/src/components/common/TabBar.tsx
@@ -1,5 +1,6 @@
 import type { TabId } from '../../types'
 import { SoundSettings } from './SoundSettings'
+import { PlaybackControls } from './PlaybackControls'
 import { GameButton } from '../ui/GameButton'
 
 interface Tab {
@@ -104,19 +105,33 @@ const TABS: Tab[] = [
   { id: 'stats', label: 'Stats', icon: <StatsIcon /> },
 ]
 
+/** Battle playback state passed from App when in battle tab */
+export interface BattlePlaybackProps {
+  /** Whether playback is currently playing */
+  isPlaying: boolean
+  /** Callback when play/pause is toggled */
+  onPlayPause: () => void
+  /** Current speed index (0=1x, 1=1.5x, 2=2x) */
+  speedIndex: number
+  /** Callback to cycle to next speed */
+  onCycleSpeed: () => void
+}
+
 interface TabBarProps {
   /** Currently active tab */
   activeTab: TabId
   /** Callback when user clicks a tab */
   onTabChange: (tab: TabId) => void
+  /** Battle playback controls (optional - only shown during battle) */
+  battlePlayback?: BattlePlaybackProps
 }
 
 /**
  * Bottom navigation bar for arena mini-app.
- * Fixed position at bottom of screen with 2 tabs + sound settings.
+ * Fixed position at bottom of screen with 2 tabs + optional playback controls + sound settings.
  * Uses CSS classes from global.css for styling.
  */
-export function TabBar({ activeTab, onTabChange }: TabBarProps) {
+export function TabBar({ activeTab, onTabChange, battlePlayback }: TabBarProps) {
   const handleTabClick = (tabId: TabId) => {
     onTabChange(tabId)
   }
@@ -142,6 +157,14 @@ export function TabBar({ activeTab, onTabChange }: TabBarProps) {
           </GameButton>
         )
       })}
+      {battlePlayback && (
+        <PlaybackControls
+          isPlaying={battlePlayback.isPlaying}
+          onPlayPause={battlePlayback.onPlayPause}
+          speedIndex={battlePlayback.speedIndex}
+          onCycleSpeed={battlePlayback.onCycleSpeed}
+        />
+      )}
       <SoundSettings />
     </nav>
   )

--- a/apps/arena-mini-app/src/components/common/index.ts
+++ b/apps/arena-mini-app/src/components/common/index.ts
@@ -1,4 +1,7 @@
 export { TabBar } from './TabBar'
+export type { BattlePlaybackProps } from './TabBar'
+export { PlaybackControls } from './PlaybackControls'
+export type { PlaybackControlsProps } from './PlaybackControls'
 export { CountdownTimer } from './CountdownTimer'
 export { Card } from './Card'
 export { CompactCard } from './CompactCard'

--- a/apps/arena-mini-app/src/styles/global.css
+++ b/apps/arena-mini-app/src/styles/global.css
@@ -385,6 +385,29 @@ a:focus:not(:focus-visible),
   transform: scale(1.1);
 }
 
+/* =============================================================================
+   Playback Controls (Tab Bar during battle)
+   ============================================================================= */
+.playback-controls {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  padding-left: 8px;
+}
+
+.playback-btn {
+  flex: 0 1 auto;
+}
+
+/* Speed icon shows text label (1x, 1.5x, 2x) */
+.playback-controls .speed-icon {
+  font-size: 14px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  min-width: 32px;
+  text-align: center;
+}
+
 /* Page container with bottom padding for tab bar */
 .page-container {
   flex: 1;
@@ -2396,72 +2419,6 @@ a:focus:not(:focus-visible),
   display: flex;
   gap: 8px;
   justify-content: center;
-}
-
-/* Playback Controls */
-.battle-controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 16px;
-  background: var(--arena-bg-medium);
-  border-radius: 12px;
-  margin: 16px;
-}
-
-.control-btn {
-  width: 44px;
-  height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  font-size: 20px;
-}
-
-.play-btn {
-  width: 56px;
-  height: 56px;
-  font-size: 24px;
-}
-
-.play-btn.playing {
-  background: var(--arena-blue);
-}
-
-.speed-selector {
-  display: flex;
-  gap: 4px;
-  margin-left: 12px;
-  padding-left: 12px;
-  border-left: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.speed-btn {
-  padding: 6px 10px;
-  border: none;
-  background: transparent;
-  color: var(--tg-theme-hint-color);
-  font-size: 12px;
-  font-weight: 500;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.speed-btn.active {
-  background: var(--arena-orange);
-  color: white;
-}
-
-.event-counter {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: var(--tg-theme-hint-color);
-  margin-left: 12px;
-  padding-left: 12px;
-  border-left: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 /* Event Log Enhancements */
@@ -5278,24 +5235,6 @@ button,
 /* ============================================
    RPG Battle Page Styles
    ============================================ */
-
-.rpg-battle-controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 12px;
-  flex-wrap: wrap;
-}
-
-.rpg-battle-controls .control-btn {
-  min-width: 44px;
-  padding: 8px 12px;
-}
-
-.rpg-battle-controls .play-btn {
-  min-width: 56px;
-}
 
 /* Victory screen overlay */
 .rpg-victory-outer {


### PR DESCRIPTION
# Refactor Battle Playback Controls to Tab Bar

## Summary

Moves battle playback controls from the BattlePage content area to the TabBar, simplifying them to two buttons: Play/Pause and a cycling Speed button (1x → 1.5x → 2x). This provides a cleaner battle viewing experience with more screen real estate for the actual battle content.

## Changes

### New Component
- **`PlaybackControls.tsx`**: New component rendering Play/Pause and Speed buttons with SVG icons, styled to match other tab bar items

### Modified Files

| File | Changes |
|------|---------|
| `TabBar.tsx` | Added `BattlePlaybackProps` interface and optional `battlePlayback` prop; renders `PlaybackControls` when provided |
| `common/index.ts` | Added exports for `PlaybackControls` and related types |
| `App.tsx` | Lifted playback state (`isPlaying`, `speedIndex`) to App level; passes to both TabBar and BattlePage |
| `BattlePage.tsx` | Removed inline controls; receives playback state via props; syncs with parent via useEffect |
| `global.css` | Added `.playback-controls` styles; removed old `.battle-controls`, `.speed-selector`, `.event-counter` styles |

### Removed Features
- Reset button (⏮️) - users can use "Watch Again" from victory screen
- Skip to end button (⏭️) - simplified UX
- 0.5x speed option - kept only 1x, 1.5x, 2x
- Event counter display

## Technical Details

### State Flow
```
App.tsx (owns state)
├── TabBar (receives battlePlayback props)
│   └── PlaybackControls (UI only)
└── BattlePage (receives props, syncs with animation hook)
    └── useBattleAnimation (internal animation state)
```

### Bidirectional Sync
The playback state syncs bidirectionally:
1. **TabBar → BattlePage**: When user clicks Play/Pause in TabBar, `parentIsPlaying` prop changes, triggering `useEffect` that calls `play()` or `pause()` on the animation hook
2. **BattlePage → TabBar**: When animation hook's `isPlaying` changes (e.g., auto-play start, playback completion), `onPlayingChange` callback updates parent state

### Speed Control
- Speed index (0=1x, 1=1.5x, 2=2x) is passed directly to BattlePage
- Used to calculate playback multiplier: `1000 / PLAYBACK_SPEEDS[speedIndex].value`
- HP bar transition duration scales with speed

## Visual Changes

**Before:**
```
┌─────────────────────────────────────┐
│           Battle Arena              │
│  [Team A Cards]  VS  [Team B Cards] │
├─────────────────────────────────────┤
│ ⏮️  ▶️  ⏭️  │ 0.5x 1x 1.5x 2x │ 3/24 │  ← Controls in content
├─────────────────────────────────────┤
│           Event Log                 │
├─────────────────────────────────────┤
│  [Lobby]  [Stats]           [Sound] │  ← Tab bar
└─────────────────────────────────────┘
```

**After:**
```
┌─────────────────────────────────────┐
│           Battle Arena              │
│  [Team A Cards]  VS  [Team B Cards] │
├─────────────────────────────────────┤
│           Event Log                 │  ← More space for content
├─────────────────────────────────────┤
│ [Lobby] [Stats] [▶️ Play] [1x] [🔊] │  ← Controls in tab bar
└─────────────────────────────────────┘
```

## Test Plan

- [ ] Start a battle and verify controls appear in tab bar
- [ ] Click Play/Pause and verify animation responds correctly
- [ ] Click Speed button and verify it cycles 1x → 1.5x → 2x → 1x
- [ ] Verify animation speed changes when speed is cycled
- [ ] Navigate to Lobby tab and verify playback controls disappear
- [ ] Navigate back to battle and verify controls reappear with correct state
- [ ] Let battle complete and verify victory screen still works
- [ ] Click "Watch Again" and verify playback resets correctly
- [ ] Verify controls disappear when returning to lobby from victory screen

---

