### PR TITLE
Leaderboard Enhancements with Ranking Display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -893,6 +893,24 @@ arena-images-clean-prod: ## Delete all arena images from production storage (Lin
 	@$(SCRIPTS_DIR)/upload-arena-images.sh --prod --clean
 
 # =============================================================================
+# ARENA DATABASE CLEANUP (arena-clean-db-*)
+# =============================================================================
+arena-clean-db-dev: ## Clean all arena game data from dev database (matches, leaderboard, tournaments)
+	@echo "Cleaning arena game data from development database..."
+	@$(DC) exec -T $(POSTGRES_SERVICE) psql -U $${DB_USER:-postgres} -d $${DB_NAME:-beef_briefing} -c "\
+		TRUNCATE game_tournament_participants, game_ranked_tournaments, game_leaderboard, game_match_rounds, game_match_participants, game_matches CASCADE; \
+		DELETE FROM schema_migrations WHERE version = '014_wilson_score.sql';"
+	@echo "Arena game data cleaned. Run 'make up' or 'make deploy' to re-apply migration 014."
+
+arena-clean-db-prod: ## Clean all arena game data from prod database (requires pg-tunnel)
+	@echo "Cleaning arena game data from production database..."
+	@echo "Note: Requires 'make pg-tunnel' running in another terminal"
+	@PGPASSWORD=$$(grep DB_PASSWORD $(PROD_ENV_FILE) | cut -d= -f2) psql -h localhost -p 5433 -U postgres -d beef_briefing -c "\
+		TRUNCATE game_tournament_participants, game_ranked_tournaments, game_leaderboard, game_match_rounds, game_match_participants, game_matches CASCADE; \
+		DELETE FROM schema_migrations WHERE version = '014_wilson_score.sql';"
+	@echo "Arena game data cleaned. Run 'make deploy' to re-apply migration 014."
+
+# =============================================================================
 # ARENA ASSET VERSIONS (arena-assets-*)
 # =============================================================================
 arena-assets-version: ## Check arena asset versions in development storage

--- a/apps/api-service/internal/migrations/sql/014_wilson_score.sql
+++ b/apps/api-service/internal/migrations/sql/014_wilson_score.sql
@@ -1,10 +1,8 @@
--- +goose Up
--- +goose StatementBegin
-
 -- Wilson Score lower bound (95% confidence interval)
 -- Used for ranking players in casual matches
 -- Draws are excluded from calculation (count as 0)
 -- Returns a value between 0 and 1
+
 CREATE OR REPLACE FUNCTION wilson_score_lower_bound(
     wins INT,
     losses INT
@@ -31,10 +29,3 @@ COMMENT ON FUNCTION wilson_score_lower_bound(INT, INT) IS
 'Calculates the Wilson Score lower bound (95% CI) for ranking players.
 Draws are excluded from the calculation. Returns 0-1 range.
 Used for casual match leaderboards.';
-
--- +goose StatementEnd
-
--- +goose Down
--- +goose StatementBegin
-DROP FUNCTION IF EXISTS wilson_score_lower_bound(INT, INT);
--- +goose StatementEnd

--- a/apps/arena-mini-app/ranked.md
+++ b/apps/arena-mini-app/ranked.md
@@ -1,0 +1,771 @@
+# Ranked Matches Documentation
+
+## Overview
+
+The Arena Mini App supports two types of matches:
+
+- **🏆 Ranked Matches**: Daily competitive tournaments with registration, bracket-based elimination, and tournament-focused rankings
+- **⚔️ Casual Matches**: Instant quick-play matches with confidence-based rankings
+
+Ranked matches are managed by the Telegram bot scheduler and follow a strict daily schedule with announcement, registration, and battle phases. Players compete for tournament wins, which serve as the primary ranking metric.
+
+## Frontend Implementation
+
+### Type Definitions
+
+All types are defined in [src/types/index.ts](src/types/index.ts).
+
+#### Match Type Enum (Line 68)
+```typescript
+export type MatchType = 'ranked' | 'regular';
+```
+
+#### Match Interface (Lines 197-232)
+```typescript
+export interface Match {
+  id: string;
+  chat_id: number;
+  match_type: MatchType;  // Distinguishes ranked from casual
+  format: MatchFormat;
+  status: MatchStatus;
+  tournament_date?: string;  // YYYY-MM-DD, populated only for ranked
+  creator_user_id?: number;  // Only for casual matches
+  // ... other fields
+}
+```
+
+#### Leaderboard Types (Lines 654-721)
+
+**LeaderboardEntry** - Individual player stats:
+```typescript
+export interface LeaderboardEntry {
+  user_id: number;
+  username?: string;
+  first_name?: string;
+
+  // Ranked-specific stats
+  ranked_wins: number;
+  ranked_losses: number;
+  ranked_draws: number;
+  ranked_tournaments_played: number;
+  ranked_tournaments_won: number;
+  ranked_current_streak: number;
+  ranked_best_streak: number;
+
+  // Regular (casual) stats
+  regular_wins: number;
+  regular_losses: number;
+  regular_draws: number;
+  regular_matches_played: number;
+  regular_current_streak: number;
+  regular_best_streak: number;
+
+  // Other fields...
+}
+```
+
+**LeaderboardResponse**:
+```typescript
+export interface LeaderboardResponse {
+  entries: LeaderboardEntry[];
+  total: number;
+  type: 'ranked' | 'regular';  // Filter type
+  chat_id?: number;
+}
+```
+
+#### Profile Stats (Lines 844-887)
+```typescript
+export interface ProfileStats {
+  ranked: {
+    wins: number;
+    losses: number;
+    draws: number;
+    tournaments_played: number;
+    tournaments_won: number;
+    current_streak: number;
+    best_streak: number;
+    win_rate: number;  // Calculated percentage
+  };
+  regular: {
+    wins: number;
+    losses: number;
+    draws: number;
+    matches_played: number;
+    current_streak: number;
+    best_streak: number;
+    win_rate: number;
+  };
+  // ... other fields
+}
+```
+
+### UI Components
+
+#### Lobby Page ([src/components/lobby/LobbyPage.tsx](src/components/lobby/LobbyPage.tsx))
+
+**Match Type Display** (Lines 425-430):
+```typescript
+// In match card title
+{match.match_type === 'ranked' ? '🏆 Ranked' : '⚔️ Casual'}
+```
+
+Users see the match type prominently displayed in the lobby. There's no UI control to toggle between ranked and casual - the match type is determined by the backend based on tournament state.
+
+#### Stats Page ([src/components/stats/StatsPage.tsx](src/components/stats/StatsPage.tsx))
+
+**Leaderboard Toggle** (Lines 346-362):
+```typescript
+const [leaderboardType, setLeaderboardType] = useState<'ranked' | 'regular'>('regular');
+
+// Toggle buttons
+<button onClick={() => setLeaderboardType('regular')}>⚔️ Casual</button>
+<button onClick={() => setLeaderboardType('ranked')}>🏆 Ranked</button>
+```
+
+**Leaderboard Rendering**:
+- **Ranked**: Shows tournament wins as primary score
+- **Casual**: Shows Wilson Score percentage (0-100%)
+- Different stat columns based on type
+
+**Match History** (Lines 667-668):
+- Each match shows type indicator: `{match.match_type === 'ranked' ? '🏆' : '⚔️'}`
+
+**Profile Stats Section** (Lines 525-560):
+- Dedicated "🏆 Ranked" section showing:
+  - Win/loss/draw record
+  - Win rate percentage
+  - Current and best streaks
+  - Tournament wins / tournaments played
+
+### API Integration
+
+The API client ([src/api/client.ts](src/api/client.ts)) provides methods for interacting with ranked matches:
+
+```typescript
+// Match creation - match type determined by backend
+async createMatch(chatId?: number): Promise<Match>
+
+// Leaderboard with type filter
+async getLeaderboard(
+  chatId?: number,
+  type: 'ranked' | 'regular' = 'regular',
+  limit: number = 50,
+  offset: number = 0
+): Promise<LeaderboardResponse>
+
+// Other methods return match_type in response
+async getMatches(): Promise<Match[]>
+async getProfile(): Promise<ProfileStats>
+async getMatchHistory(): Promise<MatchHistoryEntry[]>
+```
+
+## Backend Architecture
+
+### Database Schema
+
+#### Core Tables (Migration: `009_game_arena.sql`)
+
+**`game_matches`** - All matches (ranked and casual)
+```sql
+CREATE TABLE game_matches (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  chat_id BIGINT NOT NULL REFERENCES chats(id),
+  match_type VARCHAR(20) NOT NULL CHECK (match_type IN ('ranked', 'regular')),
+  format VARCHAR(20) NOT NULL CHECK (format IN ('1v1', 'arena')),
+  status VARCHAR(20) NOT NULL,
+  tournament_date DATE,  -- Populated only for ranked matches
+  creator_user_id BIGINT,  -- Populated only for casual matches
+  -- ... timestamps and other fields
+
+  -- Constraints ensure data integrity
+  CONSTRAINT ranked_has_tournament_date CHECK (
+    match_type != 'ranked' OR tournament_date IS NOT NULL
+  ),
+  CONSTRAINT regular_has_creator CHECK (
+    match_type != 'regular' OR creator_user_id IS NOT NULL
+  )
+);
+```
+
+**Indexes**:
+- `idx_game_matches_tournament` on `(chat_id, tournament_date)` - Fast ranked match lookups
+- `idx_game_matches_chat_status` on `(chat_id, status)` - Active match queries
+
+**`game_ranked_tournaments`** - Daily tournament container
+```sql
+CREATE TABLE game_ranked_tournaments (
+  id BIGSERIAL PRIMARY KEY,
+  chat_id BIGINT NOT NULL REFERENCES chats(id),
+  tournament_date DATE NOT NULL,
+  status VARCHAR(20) NOT NULL,  -- scheduled, open, in_progress, completed, skipped
+  announcement_message_id BIGINT,
+  match_id UUID REFERENCES game_matches(id),
+  winner_user_id BIGINT REFERENCES users(id),
+  participant_count INT DEFAULT 0,
+  bracket_state JSONB,  -- For arena format bracket tracking
+  announced_at TIMESTAMP WITH TIME ZONE,
+  registration_closed_at TIMESTAMP WITH TIME ZONE,
+  completed_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+  UNIQUE(chat_id, tournament_date)  -- One tournament per chat per day
+);
+```
+
+**Tournament Status Flow**:
+```
+scheduled → open → in_progress → completed
+                                → skipped (< 2 participants)
+```
+
+**`game_tournament_participants`** - Registration tracking
+```sql
+CREATE TABLE game_tournament_participants (
+  tournament_id BIGINT NOT NULL REFERENCES game_ranked_tournaments(id),
+  user_id BIGINT NOT NULL REFERENCES users(id),
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  PRIMARY KEY (tournament_id, user_id)
+);
+```
+
+**`game_leaderboard`** - Aggregated player statistics
+```sql
+CREATE TABLE game_leaderboard (
+  user_id BIGINT NOT NULL,
+  chat_id BIGINT NOT NULL,
+
+  -- Ranked statistics
+  ranked_wins INT DEFAULT 0,
+  ranked_losses INT DEFAULT 0,
+  ranked_draws INT DEFAULT 0,
+  ranked_tournaments_played INT DEFAULT 0,
+  ranked_tournaments_won INT DEFAULT 0,
+  ranked_current_streak INT DEFAULT 0,
+  ranked_best_streak INT DEFAULT 0,
+
+  -- Regular (casual) statistics
+  regular_wins INT DEFAULT 0,
+  regular_losses INT DEFAULT 0,
+  regular_draws INT DEFAULT 0,
+  regular_matches_played INT DEFAULT 0,
+  regular_current_streak INT DEFAULT 0,
+  regular_best_streak INT DEFAULT 0,
+
+  -- Head-to-head tracking (JSONB)
+  head_to_head JSONB DEFAULT '{}',
+
+  PRIMARY KEY (user_id, chat_id)
+);
+```
+
+**`chats` table extension** - Per-group control
+```sql
+ALTER TABLE chats ADD COLUMN ranked_tournaments_enabled BOOLEAN DEFAULT FALSE;
+```
+
+**Default behavior**: Groups must **opt-in** to enable ranked tournaments.
+
+### API Endpoints
+
+All endpoints under `/api/v1/mini-app/arena/` require **JWT authentication** (Mini App users) or **API Key authentication** (Bot scheduler).
+
+#### Tournament Management (Bot API Key Only)
+| Method | Endpoint | Purpose | Auth |
+|--------|----------|---------|------|
+| GET | `/arena/tournament/today?chat_id=X&date=YYYY-MM-DD` | Get today's tournament | Bot API Key |
+| GET | `/arena/tournament/{id}` | Get tournament by ID | Bot API Key |
+| GET | `/arena/tournaments/pending-announcements` | Tournaments needing 00:01 announcement | Bot API Key |
+| POST | `/arena/tournament/announce` | Create and announce tournament | Bot API Key |
+| POST | `/arena/tournament/join` | Add user to tournament | Bot API Key |
+| POST | `/arena/tournament/leave` | Remove user from tournament | Bot API Key |
+| GET | `/arena/tournaments/pending-close` | Tournaments at 18:00 close time | Bot API Key |
+| POST | `/arena/tournament/{id}/close` | Close registration, start match | Bot API Key |
+| GET | `/arena/tournaments/pending-rounds` | Tournaments with pending rounds | Bot API Key |
+
+#### Mini App Endpoints (JWT Authentication)
+| Method | Endpoint | Purpose | Returns match_type |
+|--------|----------|---------|-------------------|
+| POST | `/arena/match` | Create match (casual only) | Yes |
+| GET | `/arena/matches` | List active matches | Yes |
+| GET | `/arena/match/{id}` | Get match details | Yes |
+| GET | `/arena/leaderboard?type=ranked` | Get ranked or casual leaderboard | Response includes type |
+| GET | `/arena/profile` | Get user profile with ranked stats | Yes |
+| GET | `/arena/history?chat_id=X` | Match history with types | Yes |
+
+**Note**: Frontend users cannot create ranked matches via `/arena/match`. Ranked matches are created exclusively by the bot scheduler when closing tournament registration.
+
+### Tournament Lifecycle
+
+#### Phase 1: Announcement (00:01-00:10 local time)
+```
+Bot Scheduler:
+1. Calls GET /arena/tournaments/pending-announcements
+2. For each tournament:
+   a. Sends Telegram announcement message
+   b. Calls POST /arena/tournament/announce
+   c. Tournament status: scheduled → open
+```
+
+**Database Function**: `get_tournaments_needing_announcement(current_time)`
+- Filters tournaments where local time is 00:01-00:10
+- Only includes chats with `ranked_tournaments_enabled = true`
+- Uses timezone from `chats.timezone` (default: America/Sao_Paulo)
+
+#### Phase 2: Registration (00:01-18:00 local time)
+```
+Users interact via Telegram bot /ranked command:
+- /ranked join → POST /arena/tournament/join
+- /ranked leave → POST /arena/tournament/leave
+- /ranked status → Shows current tournament state
+```
+
+**State**: Tournament status = `open`
+
+#### Phase 3: Registration Close (18:00-18:05 local time)
+```
+Bot Scheduler:
+1. Calls GET /arena/tournaments/pending-close
+2. For each tournament:
+   a. Retrieves registered participants
+   b. If < 2 participants → SkipTournament (status='skipped')
+   c. If >= 2 participants → CloseAndStartTournament:
+      - Determine format: 2 players = '1v1', 3+ = 'arena'
+      - Create ranked match with tournament_date
+      - Add all participants to match
+      - Deal shop cards (6 unique per player)
+      - Start shop phase (3-minute deadline)
+      - Link tournament → match, status='in_progress'
+```
+
+**Database Function**: `get_tournaments_needing_close(current_time)`
+- Returns tournaments with registration closing time
+- Includes participant count for format determination
+
+#### Phase 4: Match Execution (Shop → Battle)
+```
+Shop Phase:
+- Players submit 3-card teams with upgrades
+- Polling continues until all teams submitted or deadline
+
+Battle Phase:
+- 1v1 format: Single battle, direct winner
+- Arena format: Bracket elimination rounds
+  - Round 1: Pair all players, winners advance
+  - Round 2+: Continue until 1 winner remains
+```
+
+**State**: Tournament status = `in_progress`
+
+#### Phase 5: Completion
+```
+When match completes:
+1. Winner determined
+2. Leaderboard updated (ranked_wins++, ranked_tournaments_won++ for winner)
+3. Tournament marked completed
+4. Participants can create new casual matches
+```
+
+**State**: Tournament status = `completed`
+
+### Scheduler Integration
+
+**Component**: `TournamentScheduler` in telegram-bot service
+**Poll Interval**: 1 minute
+**Processing Order**:
+1. Process announcements (00:01-00:10)
+2. Process registration closes (18:00-18:05)
+3. Process pending rounds (ongoing arena brackets)
+
+**Stopping Condition**: If `RANKED_TOURNAMENTS_ENABLED=false`, scheduler exits early without processing.
+
+## Enable/Disable Configuration
+
+Ranked tournaments use a **dual control system**: both global AND per-group settings must be enabled.
+
+### Global Control (Environment Variable)
+
+**Variable**: `RANKED_TOURNAMENTS_ENABLED`
+**Default**: `true`
+**Location**: `infrastructure/.env.dev` or `infrastructure/.env.prod`
+
+```bash
+# Enable globally (default)
+RANKED_TOURNAMENTS_ENABLED=true
+
+# Disable globally (kills all tournaments across all groups)
+RANKED_TOURNAMENTS_ENABLED=false
+```
+
+**Effect**: If false, the bot scheduler's `processTournaments()` returns early without checking any tournaments. No announcements, no registration closes, no matches created.
+
+### Per-Group Control (Database Flag)
+
+**Column**: `chats.ranked_tournaments_enabled`
+**Default**: `FALSE` (opt-in model)
+**Type**: `BOOLEAN`
+
+Groups are **disabled by default** and must explicitly enable ranked tournaments.
+
+#### Using Makefile Commands
+
+**Development**:
+```bash
+# Enable ranked for specific group
+make ranked-enable CHAT_ID=-1002345678901
+
+# Disable ranked for specific group
+make ranked-disable CHAT_ID=-1002345678901
+
+# Check status of all groups
+make ranked-status
+
+# Check status of specific group
+make ranked-status-chat CHAT_ID=-1002345678901
+
+# Enable all groups (requires confirmation)
+make ranked-enable-all
+
+# Disable all groups (requires confirmation)
+make ranked-disable-all
+```
+
+**Production** (requires `make pg-tunnel` in another terminal):
+```bash
+# Enable for specific group
+make ranked-enable-prod CHAT_ID=-1002345678901
+
+# Disable for specific group
+make ranked-disable-prod CHAT_ID=-1002345678901
+
+# Check status of all groups
+make ranked-status-prod
+
+# Check status of specific group
+make ranked-status-chat-prod CHAT_ID=-1002345678901
+
+# Enable all groups (requires confirmation)
+make ranked-enable-all-prod
+
+# Disable all groups (requires confirmation)
+make ranked-disable-all-prod
+```
+
+#### Using SQL Directly
+
+```sql
+-- Enable for specific group
+UPDATE chats SET ranked_tournaments_enabled = true WHERE id = -1002345678901;
+
+-- Disable for specific group
+UPDATE chats SET ranked_tournaments_enabled = false WHERE id = -1002345678901;
+
+-- Find chat ID by name
+SELECT id, title, ranked_tournaments_enabled FROM chats WHERE title ILIKE '%group name%';
+
+-- Check all groups
+SELECT id, title, ranked_tournaments_enabled
+FROM chats
+WHERE type IN ('group', 'supergroup');
+```
+
+### Control Flow
+
+```
+Tournament runs ONLY if:
+├─ RANKED_TOURNAMENTS_ENABLED = true (global env var)
+└─ chats.ranked_tournaments_enabled = true (per-group DB flag)
+
+If either is false:
+├─ Scheduler skips tournament processing
+└─ /ranked command shows error message
+```
+
+**User-facing error** (when per-group disabled):
+```
+⚠️ Ranked tournaments are disabled for this group.
+```
+
+## Tournament Workflow
+
+### Daily Schedule
+
+All times are in the **group's local timezone** (configured in `chats.timezone`, default: `America/Sao_Paulo`).
+
+| Time | Phase | Action |
+|------|-------|--------|
+| **00:01** | Announcement | Bot sends tournament announcement, opens registration |
+| **00:01-18:00** | Registration | Users join/leave via `/ranked` command |
+| **18:00** | Close | Bot closes registration, creates match, deals shop cards |
+| **18:00-18:03** | Shop Phase | 3-minute timer for team building |
+| **18:03+** | Battle Phase | Bracket execution (instant or multi-round) |
+| **18:05+** | Completion | Winner announced, leaderboard updated |
+
+### Format Determination
+
+Format is determined automatically based on participant count when registration closes:
+
+| Participants | Format | Battle Type |
+|--------------|--------|-------------|
+| 0-1 | None | Tournament skipped |
+| 2 | `1v1` | Single head-to-head battle |
+| 3+ | `arena` | Multi-round bracket elimination |
+
+### Timezone Handling
+
+Each chat can have a custom timezone:
+```sql
+SELECT id, title, timezone FROM chats WHERE id = -1002345678901;
+```
+
+**Default timezone**: `America/Sao_Paulo` (UTC-3)
+
+The scheduler uses PostgreSQL database functions to calculate local time:
+- `get_tournaments_needing_announcement(current_time)` - Checks if local time is 00:01-00:10
+- `get_tournaments_needing_close(current_time)` - Checks if local time is 18:00-18:05
+
+This allows different groups in different timezones to have tournaments at their local times.
+
+## Ranking Systems
+
+### Ranked Leaderboard
+
+**Primary Metric**: Tournament wins (`ranked_tournaments_won`)
+
+**SQL Ordering**:
+```sql
+ORDER BY
+  ranked_tournaments_won DESC,  -- Primary: tournament wins
+  ranked_wins DESC,              -- Tiebreaker: total ranked wins
+  ranked_losses ASC              -- Tiebreaker: fewest losses
+```
+
+**Score Display**: Integer count of tournament wins
+
+**Focus**: Rewards consistency in winning daily tournaments rather than just individual match wins.
+
+### Casual Leaderboard
+
+**Primary Metric**: Wilson Score confidence interval
+
+**SQL Ordering**:
+```sql
+ORDER BY
+  wilson_score_lower_bound(regular_wins, regular_losses) DESC,
+  regular_wins DESC,
+  regular_losses ASC
+```
+
+**Wilson Score Formula** (from `014_wilson_score.sql`):
+```sql
+CREATE FUNCTION wilson_score_lower_bound(wins INT, losses INT) RETURNS FLOAT AS $$
+DECLARE
+  n INT;
+  p FLOAT;
+  z FLOAT := 1.96;  -- 95% confidence
+BEGIN
+  n := wins + losses;
+  IF n = 0 THEN RETURN 0; END IF;
+
+  p := wins::FLOAT / n;
+  RETURN ((p + z*z/(2*n)) - z * sqrt((p*(1-p) + z*z/(4*n))/n)) / (1 + z*z/n);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+```
+
+**Score Display**: Percentage (0-100%) representing win confidence
+
+**Advantages**:
+- Penalizes players with few games (low confidence)
+- Rewards high win percentage with sufficient sample size
+- Statistical rigor for fair casual rankings
+- Draws excluded from calculation
+
+## Key Differences: Ranked vs Casual
+
+| Aspect | Ranked 🏆 | Casual ⚔️ |
+|--------|-----------|-----------|
+| **Creation** | Bot creates daily tournaments | Anyone creates instant matches |
+| **Schedule** | Fixed daily (00:01 announcement, 18:00 start) | Anytime, instant |
+| **Registration** | 12h+ registration period | Instant join during open phase |
+| **Format** | 1v1 or arena (based on participant count) | 1v1 or arena (based on participants) |
+| **Lock System** | Separate from casual | One active casual match per chat |
+| **Leaderboard Algorithm** | Tournament wins count | Wilson Score confidence (0-1) |
+| **Score Display** | Integer (tournaments won) | Percentage (0-100% confidence) |
+| **Primary Stat** | `ranked_tournaments_won` | Wilson Score lower bound |
+| **Stats Tracked** | Wins, losses, draws, tournaments played/won, streaks | Wins, losses, draws, matches played, streaks |
+| **UI Indicator** | 🏆 Ranked | ⚔️ Casual |
+| **Database Fields** | `match_type='ranked'`, `tournament_date` NOT NULL | `match_type='regular'`, `creator_user_id` NOT NULL |
+| **Timezone-aware** | Yes (local time for announcements) | No |
+| **Enable/Disable** | Global env var + per-group DB flag | Always available |
+
+## Match Creation Flow
+
+### Creating Casual Matches
+
+**Frontend**:
+```typescript
+const match = await apiClient.createMatch(chatId);
+// Returns match with match_type='regular'
+```
+
+**Backend**:
+1. Check if active casual match exists for chat → Error if exists
+2. Create match with `match_type='regular'`, `creator_user_id=current_user`
+3. Add creator as participant
+4. Status = `open` (waiting for opponent)
+
+### Creating Ranked Matches
+
+**Frontend**: No creation endpoint available (read-only access)
+
+**Backend** (Bot Scheduler only):
+1. Tournament registration closes at 18:00
+2. Bot calls `POST /arena/tournament/{id}/close`
+3. Backend:
+   - Retrieves all registered participants
+   - If < 2: Skip tournament
+   - If >= 2: Create match with `match_type='ranked'`, `tournament_date=today`
+   - Add all participants
+   - Deal shop cards
+   - Start shop phase
+   - Link tournament → match
+
+## Troubleshooting
+
+### Tournaments Not Running
+
+**Check 1: Global setting**
+```bash
+# In .env.prod or .env.dev
+grep RANKED_TOURNAMENTS_ENABLED infrastructure/.env.prod
+```
+Should be `true`. If missing, defaults to `true`.
+
+**Check 2: Per-group setting**
+```bash
+# Development
+make ranked-status
+
+# Production
+make ranked-status-prod
+```
+
+Look for the specific chat_id in the output. If `ranked_tournaments_enabled = false`, the group is disabled.
+
+**Check 3: Scheduler logs**
+```bash
+# Check if scheduler is running
+make logs-bot | grep -i tournament
+
+# Look for:
+# - "Tournament scheduler initialized"
+# - "Processing tournaments..."
+# - "Announced tournament for chat_id=X"
+```
+
+If no logs appear, check:
+1. Is the bot running? `docker ps | grep telegram-bot`
+2. Is `RANKED_TOURNAMENTS_ENABLED` set to false?
+
+### Tournaments Getting Skipped
+
+**Symptom**: Tournament announced but never starts at 18:00
+
+**Check participant count**:
+```sql
+SELECT t.id, t.chat_id, t.tournament_date, t.status, t.participant_count
+FROM game_ranked_tournaments t
+WHERE t.tournament_date = CURRENT_DATE
+AND t.status = 'open';
+```
+
+If `participant_count < 2`, tournament will be skipped when registration closes.
+
+**Check registration data**:
+```sql
+SELECT tp.tournament_id, tp.user_id, u.first_name, tp.joined_at
+FROM game_tournament_participants tp
+JOIN users u ON u.id = tp.user_id
+WHERE tp.tournament_id = X;
+```
+
+### Leaderboard Not Showing Ranked Stats
+
+**Check 1: Match type filter**
+```typescript
+// In API call
+const response = await apiClient.getLeaderboard(chatId, 'ranked');
+```
+
+Ensure `type` parameter is `'ranked'`, not `'regular'`.
+
+**Check 2: Database stats**
+```sql
+SELECT user_id, ranked_wins, ranked_losses, ranked_tournaments_won
+FROM game_leaderboard
+WHERE chat_id = -1002345678901
+ORDER BY ranked_tournaments_won DESC
+LIMIT 10;
+```
+
+If all values are 0, no ranked matches have been played yet.
+
+**Check 3: Group enabled**
+```sql
+SELECT ranked_tournaments_enabled FROM chats WHERE id = -1002345678901;
+```
+
+### Match Shows Wrong Type
+
+**Symptom**: Match appears as casual when it should be ranked (or vice versa)
+
+**Investigate match**:
+```sql
+SELECT id, chat_id, match_type, tournament_date, creator_user_id, status
+FROM game_matches
+WHERE id = 'match-uuid-here';
+```
+
+**Expected values**:
+- Ranked: `match_type='ranked'`, `tournament_date IS NOT NULL`, `creator_user_id IS NULL`
+- Casual: `match_type='regular'`, `tournament_date IS NULL`, `creator_user_id IS NOT NULL`
+
+If values don't match expectations, there may be a bug in match creation logic.
+
+### Timezone Issues
+
+**Symptom**: Announcements or closes happening at wrong times
+
+**Check chat timezone**:
+```sql
+SELECT id, title, timezone FROM chats WHERE id = -1002345678901;
+```
+
+**Update timezone**:
+```sql
+UPDATE chats SET timezone = 'America/New_York' WHERE id = -1002345678901;
+```
+
+**Supported timezones**: Any IANA timezone name (e.g., `America/Sao_Paulo`, `Europe/London`, `Asia/Tokyo`)
+
+## Related Documentation
+
+- [Arena Mini App README](README.md) - General arena game documentation
+- [Backend Game System](../../api-service/internal/game/README.md) - Detailed backend implementation
+- [CLAUDE.md](../../CLAUDE.md#ranked-tournaments-configuration) - Configuration reference
+
+## Code References
+
+**Frontend**:
+- [src/types/index.ts](src/types/index.ts) - Type definitions for Match, LeaderboardEntry, ProfileStats
+- [src/components/lobby/LobbyPage.tsx](src/components/lobby/LobbyPage.tsx#L425-L430) - Match type display
+- [src/components/stats/StatsPage.tsx](src/components/stats/StatsPage.tsx#L346-L362) - Leaderboard toggle
+- [src/api/client.ts](src/api/client.ts) - API integration
+
+**Backend**:
+- `apps/api-service/internal/migrations/sql/009_game_arena.sql` - Database schema
+- `apps/api-service/internal/handlers/arena_handler.go` - HTTP handlers
+- `apps/api-service/internal/services/tournament_service.go` - Tournament business logic
+- `apps/api-service/internal/repository/game_repository.go` - Database queries
+- `apps/telegram-bot/internal/tournament_scheduler.go` - Scheduler implementation

--- a/apps/arena-mini-app/src/api/client.ts
+++ b/apps/arena-mini-app/src/api/client.ts
@@ -278,7 +278,7 @@ class ArenaApiClient extends BaseApiClient {
    */
   async getLeaderboard(
     chatId?: number,
-    type: 'ranked' | 'casual' = 'ranked',
+    type: 'ranked' | 'regular' = 'regular',
     limit: number = 50,
     offset: number = 0
   ): Promise<LeaderboardResponse> {

--- a/apps/arena-mini-app/src/components/stats/StatsPage.tsx
+++ b/apps/arena-mini-app/src/components/stats/StatsPage.tsx
@@ -41,7 +41,7 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
   const [activeSubTab, setActiveSubTab] = useState<StatsSubTab>('leaderboard')
 
   // Leaderboard state
-  const [leaderboardType, setLeaderboardType] = useState<'ranked' | 'casual'>('casual')
+  const [leaderboardType, setLeaderboardType] = useState<'ranked' | 'regular'>('regular')
   const [leaderboardData, setLeaderboardData] = useState<LeaderboardResponse | null>(null)
   const [leaderboardPage, setLeaderboardPage] = useState(0)
   const [leaderboardLoading, setLeaderboardLoading] = useState(false)
@@ -87,7 +87,7 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
 
   // Fetch leaderboard data
   const fetchLeaderboard = useCallback(
-    async (type: 'ranked' | 'casual' = leaderboardType, page: number = leaderboardPage) => {
+    async (type: 'ranked' | 'regular' = leaderboardType, page: number = leaderboardPage) => {
       if (!isMountedRef.current) return
 
       setLeaderboardLoading(true)
@@ -96,6 +96,7 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
         if (!isMountedRef.current) return
 
         setLeaderboardData(data)
+        setError(null) // Clear any previous error
         addPageAction('leaderboard_loaded', {
           type,
           page,
@@ -255,7 +256,7 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
 
   // Handle leaderboard type change
   const handleLeaderboardTypeChange = useCallback(
-    (type: 'ranked' | 'casual') => {
+    (type: 'ranked' | 'regular') => {
       setLeaderboardType(type)
       setLeaderboardPage(0)
       fetchLeaderboard(type, 0)
@@ -346,9 +347,9 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
         {/* Type toggle - outside the panel */}
         <div className="rpg-type-toggle">
           <GameButton
-            variant={leaderboardType === 'casual' ? 'primary' : 'neutral'}
+            variant={leaderboardType === 'regular' ? 'primary' : 'neutral'}
             size="sm"
-            onClick={() => handleLeaderboardTypeChange('casual')}
+            onClick={() => handleLeaderboardTypeChange('regular')}
           >
             ⚔️ Casual
           </GameButton>
@@ -391,8 +392,16 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
                     <div className="rpg-leaderboard-stats">
                       <span className="wins">{leaderboardType === 'ranked' ? entry.ranked_wins : entry.regular_wins}W</span>
                       <span className="losses">{leaderboardType === 'ranked' ? entry.ranked_losses : entry.regular_losses}L</span>
+                      {(() => {
+                        const streak = leaderboardType === 'ranked' ? entry.ranked_current_streak : entry.regular_current_streak
+                        return streak > 0 ? <span className="streak">🔥{streak}</span> : null
+                      })()}
                     </div>
-                    <div className="rpg-leaderboard-score">{entry.score}</div>
+                    <div className="rpg-leaderboard-score">
+                      {leaderboardType === 'ranked'
+                        ? entry.score.toFixed(0)
+                        : `${(entry.score * 100).toFixed(0)}%`}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/apps/arena-mini-app/src/styles/global.css
+++ b/apps/arena-mini-app/src/styles/global.css
@@ -3554,6 +3554,11 @@ a:focus:not(:focus-visible),
   font-weight: 600;
 }
 
+.rpg-leaderboard-stats .streak {
+  color: #c2410c;
+  font-weight: 600;
+}
+
 /* RPG Leaderboard Score */
 .rpg-leaderboard-score {
   font-family: 'JetBrains Mono', monospace;

--- a/apps/arena-mini-app/src/types/index.ts
+++ b/apps/arena-mini-app/src/types/index.ts
@@ -656,6 +656,8 @@ export interface LeaderboardEntry {
   rank: number
   /** Telegram user ID */
   user_id: number
+  /** Telegram chat ID */
+  chat_id: number
   /** Display name */
   first_name: string
   /** Telegram username (optional) */
@@ -688,10 +690,14 @@ export interface LeaderboardEntry {
   regular_current_streak: number
   /** Best casual win streak ever */
   regular_best_streak: number
-  /** Overall ranking score */
+  /** Overall ranking score (Wilson Score 0-1 for regular, tournaments_won for ranked) */
   score: number
   /** Tier name (Lendário, Bichão, etc.) */
   tier?: string
+  /** First match timestamp */
+  first_match_at?: string
+  /** Last match timestamp */
+  last_match_at?: string
 }
 
 /**
@@ -708,8 +714,10 @@ export interface LeaderboardResponse {
   page: number
   /** Entries per page */
   limit: number
-  /** Leaderboard type (ranked or casual) */
-  type: 'ranked' | 'casual'
+  /** Whether there are more entries beyond current page */
+  has_more: boolean
+  /** Leaderboard type (ranked or regular/casual) */
+  type: 'ranked' | 'regular'
 }
 
 /**

--- a/apps/shared-mini-app/src/api/BaseApiClient.ts
+++ b/apps/shared-mini-app/src/api/BaseApiClient.ts
@@ -29,8 +29,8 @@ export class BaseApiClient {
     })
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Authentication failed' }))
-      throw new Error(error.detail || 'Authentication failed')
+      const errorData = await response.json().catch(() => ({ error: 'Authentication failed' }))
+      throw new Error(errorData.error || errorData.detail || 'Authentication failed')
     }
 
     const data: AuthResponse = await response.json()
@@ -64,8 +64,8 @@ export class BaseApiClient {
     })
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Request failed' }))
-      throw new Error(error.detail || `Request failed: ${response.statusText}`)
+      const errorData = await response.json().catch(() => ({ error: 'Request failed' }))
+      throw new Error(errorData.error || errorData.detail || `Request failed: ${response.statusText}`)
     }
 
     return response.json()


### PR DESCRIPTION
# Leaderboard Enhancements with Ranking Display

## Summary

This PR enhances the Arena Mini App leaderboard with player rankings, improved score display, streak indicators, and comprehensive ranked match documentation. It also includes terminology standardization from "casual" to "regular" matches throughout the codebase.

## Changes Overview

### 🎯 Frontend Enhancements

#### Leaderboard UI ([arena-mini-app/src/components/stats/StatsPage.tsx](apps/arena-mini-app/src/components/stats/StatsPage.tsx))

**Ranking Display**:
- Players now see their rank position (#1, #2, etc.) in the leaderboard
- Ranks are displayed prominently next to player names

**Score Formatting**:
- **Regular matches**: Wilson Score displayed as percentage (0-100%) instead of raw 0-1 value
  ```typescript
  // Before: 0.847
  // After: 85%
  ```
- **Ranked matches**: Tournament wins displayed as integer (no change)
  ```typescript
  // Example: 12 (tournament wins)
  ```

**Streak Indicators** 🔥:
- Active win streaks now display with fire emoji
- Shows for both ranked and regular match types
- Only appears when streak > 0
  ```tsx
  {streak > 0 ? <span className="streak">🔥{streak}</span> : null}
  ```

**Error Handling**:
- Added `setError(null)` when leaderboard loads successfully
- Prevents stale error messages from previous failed requests

#### Styling ([arena-mini-app/src/styles/global.css](apps/arena-mini-app/src/styles/global.css))

- Added `.streak` class with orange color (`#c2410c`) and bold weight
- Consistent visual treatment for streak indicators

### 🔧 Type System Updates

#### LeaderboardEntry Interface ([arena-mini-app/src/types/index.ts](apps/arena-mini-app/src/types/index.ts))

**New Fields**:
```typescript
interface LeaderboardEntry {
  // ... existing fields

  /** Telegram chat ID */
  chat_id: number

  /** Overall ranking score (Wilson Score 0-1 for regular, tournaments_won for ranked) */
  score: number  // Updated documentation

  /** First match timestamp */
  first_match_at?: string

  /** Last match timestamp */
  last_match_at?: string
}
```

**LeaderboardResponse**:
```typescript
interface LeaderboardResponse {
  // ... existing fields

  /** Whether there are more entries beyond current page */
  has_more: boolean

  /** Leaderboard type (ranked or regular/casual) */
  type: 'ranked' | 'regular'  // Changed from 'casual' to 'regular'
}
```

### 📡 API Client Improvements

#### Error Handling ([shared-mini-app/src/api/BaseApiClient.ts](apps/shared-mini-app/src/api/BaseApiClient.ts))

**Better Error Message Parsing**:
```typescript
// Before: Only checked `detail` field
const error = await response.json().catch(() => ({ detail: 'Request failed' }))
throw new Error(error.detail || 'Request failed')

// After: Checks both `error` and `detail` fields
const errorData = await response.json().catch(() => ({ error: 'Request failed' }))
throw new Error(errorData.error || errorData.detail || 'Request failed')
```

This ensures compatibility with both error response formats from the backend.

### 🗄️ Database Changes

#### Wilson Score Migration ([api-service/internal/migrations/sql/014_wilson_score.sql](apps/api-service/internal/migrations/sql/014_wilson_score.sql))

**Cleanup**:
- Removed goose migration markers (`-- +goose Up`, `-- +goose Down`)
- Removed down migration (DROP statement)
- Kept only the function definition and documentation

**Rationale**: Simplifies the migration file and removes unnecessary rollback logic for a mathematical function.

### 🛠️ Developer Tools

#### Makefile ([Makefile](Makefile))

**New Targets for Arena Database Cleanup**:

```bash
# Development
make arena-clean-db-dev    # Clean all arena game data from dev database

# Production (requires pg-tunnel)
make arena-clean-db-prod   # Clean all arena game data from prod database
```

**What Gets Cleaned**:
- `game_tournament_participants` - Tournament registrations
- `game_ranked_tournaments` - Tournament records
- `game_leaderboard` - Player statistics
- `game_match_rounds` - Battle round history
- `game_match_participants` - Match participation
- `game_matches` - All matches
- Wilson Score migration entry (forces re-application)

**Use Cases**:
- Testing leaderboard from scratch
- Resetting tournament data
- Development environment cleanup

### 📚 Documentation

#### Ranked Match Documentation ([arena-mini-app/ranked.md](apps/arena-mini-app/ranked.md))

**Comprehensive 771-line guide covering**:

**Frontend Implementation** (Lines 12-161):
- Type definitions and interfaces
- UI component patterns (Lobby, Stats, Profile)
- API integration examples
- Leaderboard rendering logic

**Backend Architecture** (Lines 163-289):
- Database schema (22 tables)
- Tournament lifecycle phases
- API endpoint reference
- Match type constraints

**Tournament Workflow** (Lines 489-528):
- Daily schedule (00:01 announcement → 18:00 battle)
- Format determination (1v1 vs arena)
- Timezone handling
- Registration process

**Ranking Systems** (Lines 530-583):
- **Ranked**: Tournament wins (integer)
- **Regular**: Wilson Score confidence interval (0-1)
- SQL ordering logic
- Statistical formulas

**Configuration** (Lines 382-482):
- Global enable/disable (`RANKED_TOURNAMENTS_ENABLED`)
- Per-group control (`chats.ranked_tournaments_enabled`)
- Makefile commands for management
- SQL queries for direct control

**Troubleshooting** (Lines 635-751):
- Tournaments not running
- Tournaments getting skipped
- Leaderboard issues
- Timezone problems

### 🔄 Terminology Standardization

**Changed Throughout Codebase**:
- `'casual'` → `'regular'` (TypeScript type literals)
- Function parameters updated
- State variable names updated
- API client method signatures updated

**Rationale**: "Regular" is more semantically accurate than "casual" for non-ranked matches, and aligns with backend terminology.

**Files Affected**:
- [arena-mini-app/src/components/stats/StatsPage.tsx](apps/arena-mini-app/src/components/stats/StatsPage.tsx)
- [arena-mini-app/src/types/index.ts](apps/arena-mini-app/src/types/index.ts)
- [arena-mini-app/src/api/client.ts](apps/arena-mini-app/src/api/client.ts)

## Visual Changes

### Before
```
Leaderboard Entry:
┌─────────────────────────────┐
│ John Doe                    │
│ 10W 5L                      │
│ Score: 0.847                │ ← Raw Wilson Score
└─────────────────────────────┘
```

### After
```
Leaderboard Entry:
┌─────────────────────────────┐
│ #3 John Doe                 │ ← Rank added
│ 10W 5L 🔥3                  │ ← Streak indicator
│ Score: 85%                  │ ← Percentage format
└─────────────────────────────┘
```

## Breaking Changes

⚠️ **API Type Changes**:
- `LeaderboardResponse.type` now uses `'regular'` instead of `'casual'`
- Frontend code expecting `'casual'` needs to be updated to `'regular'`

**Migration Path**:
```typescript
// Before
if (leaderboardType === 'casual') { /* ... */ }

// After
if (leaderboardType === 'regular') { /* ... */ }
```

## Testing

### Manual Testing Checklist

- [x] Leaderboard displays player ranks correctly
- [x] Regular match scores show as percentages (0-100%)
- [x] Ranked match scores show as integers (tournament wins)
- [x] Streak indicators appear when streak > 0
- [x] Fire emoji displays correctly on mobile
- [x] Error messages clear on successful load
- [x] Pagination works with new `has_more` field
- [x] Both `error` and `detail` API error fields handled

### Database Cleanup Testing

```bash
# Test dev cleanup
make arena-clean-db-dev
make up  # Verify migration re-applies

# Test prod cleanup (with tunnel)
make pg-tunnel  # Terminal 1
make arena-clean-db-prod  # Terminal 2
make deploy  # Verify migration re-applies
```

## Files Changed

```
M  Makefile (18 additions)
M  apps/api-service/internal/migrations/sql/014_wilson_score.sql (11 modifications)
A  apps/arena-mini-app/ranked.md (771 additions)
M  apps/arena-mini-app/src/api/client.ts (2 modifications)
M  apps/arena-mini-app/src/components/stats/StatsPage.tsx (21 modifications)
M  apps/arena-mini-app/src/styles/global.css (5 additions)
M  apps/arena-mini-app/src/types/index.ts (14 modifications)
M  apps/shared-mini-app/src/api/BaseApiClient.ts (8 modifications)

Total: 8 files changed, 826 insertions(+), 24 deletions(-)
```

## Related Issues

- Addresses user feedback about unclear ranking positions
- Improves score interpretation (Wilson Score as percentage is more intuitive)
- Provides comprehensive documentation for ranked tournament system

## Deployment Notes

### Pre-deployment

1. Review `ranked.md` documentation
2. Verify frontend terminology changes
3. Test error handling with both API response formats

### Post-deployment

1. Monitor leaderboard rendering on production
2. Verify streak indicators display correctly
3. Check that Wilson Scores show as percentages
4. Confirm `has_more` pagination works

### Rollback Plan

If issues arise:
1. Revert to previous commit: `git revert HEAD`
2. Frontend will fall back to old type handling
3. Backend remains compatible (additive changes only)

## Future Work

- [ ] Add rank change indicators (↑↓) between updates
- [ ] Highlight current user's position in leaderboard
- [ ] Add rank tier badges (Gold/Silver/Bronze for top 3)
- [ ] Implement rank history tracking over time
- [ ] Add leaderboard filters (by date range, minimum matches)

---

