### PR TITLE
Group-Bound Validation for Game API Endpoints

### DIFF
--- a/apps/api-service/internal/handlers/arena_handler.go
+++ b/apps/api-service/internal/handlers/arena_handler.go
@@ -220,6 +220,27 @@ func requireJWTClaims(ctx context.Context, w http.ResponseWriter) *middleware.Mi
 	return claims
 }
 
+// validateMatchChatAccess fetches a match and validates the user has access to its chat.
+// Returns the match if valid, or writes an error response and returns nil if invalid.
+func (h *ArenaHandler) validateMatchChatAccess(ctx context.Context, w http.ResponseWriter, matchID string, claims *middleware.MiniAppClaims) *services.MatchResponse {
+	match, err := h.service.GetMatch(ctx, matchID)
+	if err != nil {
+		handleServiceError(ctx, w, err, "get match")
+		return nil
+	}
+
+	if claims.ChatID == nil {
+		httputil.RespondError(w, "chat context required", http.StatusForbidden)
+		return nil
+	}
+	if *claims.ChatID != match.ChatID {
+		httputil.RespondError(w, "access denied to this chat", http.StatusForbidden)
+		return nil
+	}
+
+	return match
+}
+
 // setTransactionName sets the New Relic transaction name if a transaction exists.
 func setTransactionName(ctx context.Context, name string) {
 	if txn := newrelic.FromContext(ctx); txn != nil {

--- a/apps/api-service/internal/handlers/match_handler.go
+++ b/apps/api-service/internal/handlers/match_handler.go
@@ -193,6 +193,11 @@ func (h *ArenaHandler) HandleJoinMatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
+		return
+	}
+
 	addTransactionAttribute(ctx, "match_id", matchID)
 	addTransactionAttribute(ctx, "user_id", claims.UserID)
 
@@ -219,6 +224,11 @@ func (h *ArenaHandler) HandleLeaveMatch(w http.ResponseWriter, r *http.Request) 
 	matchID, err := extractMatchIDFromURL(r)
 	if err != nil {
 		httputil.RespondError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
 		return
 	}
 
@@ -251,6 +261,11 @@ func (h *ArenaHandler) HandleStartMatch(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
+		return
+	}
+
 	addTransactionAttribute(ctx, "match_id", matchID)
 	addTransactionAttribute(ctx, "user_id", claims.UserID)
 
@@ -277,6 +292,11 @@ func (h *ArenaHandler) HandleGetBattle(w http.ResponseWriter, r *http.Request) {
 	matchID, err := extractMatchIDFromURL(r)
 	if err != nil {
 		httputil.RespondError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
 		return
 	}
 
@@ -718,14 +738,9 @@ func (h *ArenaHandler) HandleShareResult(w http.ResponseWriter, r *http.Request)
 		txn.AddAttribute("user_id", claims.UserID)
 	}
 
-	// Get the match to verify access and status
-	match, err := h.service.GetMatch(ctx, matchID)
-	if err != nil {
-		slog.Error("failed to get match", "error", err)
-		if txn != nil {
-			txn.NoticeError(err)
-		}
-		httputil.RespondError(w, "match not found", http.StatusNotFound)
+	// Validate match belongs to user's chat
+	match := h.validateMatchChatAccess(ctx, w, matchID, claims)
+	if match == nil {
 		return
 	}
 

--- a/apps/api-service/internal/handlers/mini_app_handler.go
+++ b/apps/api-service/internal/handlers/mini_app_handler.go
@@ -609,6 +609,16 @@ func (h *MiniAppHandler) HandleGalleryImageURL(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Verify chat access - the image must belong to the user's chat
+	if claims.ChatID == nil {
+		httputil.RespondError(w, "chat context required", http.StatusForbidden)
+		return
+	}
+	if *claims.ChatID != result.ChatID {
+		httputil.RespondError(w, "access denied to this chat", http.StatusForbidden)
+		return
+	}
+
 	httputil.RespondJSON(w, result, http.StatusOK)
 }
 

--- a/apps/api-service/internal/handlers/shop_handler.go
+++ b/apps/api-service/internal/handlers/shop_handler.go
@@ -29,6 +29,11 @@ func (h *ArenaHandler) HandleGetShop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
+		return
+	}
+
 	addTransactionAttribute(ctx, "match_id", matchID)
 	addTransactionAttribute(ctx, "user_id", claims.UserID)
 
@@ -55,6 +60,11 @@ func (h *ArenaHandler) HandleBuyCard(w http.ResponseWriter, r *http.Request) {
 	matchID, err := extractMatchIDFromURL(r)
 	if err != nil {
 		httputil.RespondError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
 		return
 	}
 
@@ -94,6 +104,11 @@ func (h *ArenaHandler) HandleReroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
+		return
+	}
+
 	addTransactionAttribute(ctx, "match_id", matchID)
 	addTransactionAttribute(ctx, "user_id", claims.UserID)
 
@@ -120,6 +135,11 @@ func (h *ArenaHandler) HandleUpgrade(w http.ResponseWriter, r *http.Request) {
 	matchID, err := extractMatchIDFromURL(r)
 	if err != nil {
 		httputil.RespondError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
 		return
 	}
 
@@ -165,6 +185,11 @@ func (h *ArenaHandler) HandleSetOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
+		return
+	}
+
 	var req SetOrderRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		httputil.RespondError(w, "invalid request body", http.StatusBadRequest)
@@ -198,6 +223,11 @@ func (h *ArenaHandler) HandleSubmitTeam(w http.ResponseWriter, r *http.Request) 
 	matchID, err := extractMatchIDFromURL(r)
 	if err != nil {
 		httputil.RespondError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate match belongs to user's chat
+	if h.validateMatchChatAccess(ctx, w, matchID, claims) == nil {
 		return
 	}
 

--- a/apps/api-service/internal/services/card_service.go
+++ b/apps/api-service/internal/services/card_service.go
@@ -441,6 +441,7 @@ type GalleryImagesResponse struct {
 // GalleryImageURLResponse is the response for GetGalleryImageURL.
 type GalleryImageURLResponse struct {
 	ImageID   int64  `json:"image_id"`
+	ChatID    int64  `json:"chat_id"`
 	URL       string `json:"url"`
 	ExpiresIn int    `json:"expires_in"`
 }
@@ -528,6 +529,7 @@ func (s *CardService) GetGalleryImageURL(
 
 	return &GalleryImageURLResponse{
 		ImageID:   imageID,
+		ChatID:    image.ChatID,
 		URL:       url,
 		ExpiresIn: expirySeconds,
 	}, nil

--- a/apps/api-service/internal/services/card_service_test.go
+++ b/apps/api-service/internal/services/card_service_test.go
@@ -642,6 +642,7 @@ func TestGetGalleryImageURL_ExpiryBounds(t *testing.T) {
 	// Setup test data
 	galleryImage := &repository.GalleryImage{
 		ID:          imageID,
+		ChatID:      -1001234567890,
 		StoragePath: "cards/test.png",
 	}
 	mockRepo.AddGalleryImage(galleryImage)


### PR DESCRIPTION
# Group-Bound Validation for Game API Endpoints

## Summary

This PR adds proper chat isolation validation to all game API endpoints, ensuring that users can only access matches, shop operations, and gallery resources belonging to their authenticated chat (group). Previously, endpoints extracted match IDs from URLs but didn't verify the match belonged to the user's chat context.

## Problem

Users in multiple groups could potentially access matches from other groups by manipulating match IDs in API requests. While JWT authentication verified user identity, it didn't enforce that resources belonged to the user's current chat context.

## Solution

Added `validateMatchChatAccess` helper function and applied it to all 12 affected endpoints:

### Shop Endpoints (6 endpoints)
- `GET /api/v1/mini-app/arena/match/{id}/shop`
- `POST /api/v1/mini-app/arena/match/{id}/buy`
- `POST /api/v1/mini-app/arena/match/{id}/reroll`
- `POST /api/v1/mini-app/arena/match/{id}/upgrade`
- `POST /api/v1/mini-app/arena/match/{id}/order`
- `POST /api/v1/mini-app/arena/match/{id}/team`

### Match Endpoints (5 endpoints)
- `POST /api/v1/mini-app/arena/match/{id}/join`
- `POST /api/v1/mini-app/arena/match/{id}/leave`
- `POST /api/v1/mini-app/arena/match/{id}/start`
- `GET /api/v1/mini-app/arena/match/{id}/battle`
- `POST /api/v1/mini-app/arena/match/{id}/share`

### Gallery Endpoint (1 endpoint)
- `GET /api/v1/mini-app/gallery/image/{id}`

## Changes

| File | Changes |
|------|---------|
| `arena_handler.go` | Added `validateMatchChatAccess` helper function |
| `shop_handler.go` | Added validation to 6 handlers |
| `match_handler.go` | Added validation to 5 handlers |
| `mini_app_handler.go` | Added chat validation to `HandleGalleryImageURL` |
| `card_service.go` | Added `ChatID` to `GalleryImageURLResponse` |
| `card_service_test.go` | Updated test fixture with `ChatID` |

## Validation Logic

```go
func (h *ArenaHandler) validateMatchChatAccess(ctx context.Context, w http.ResponseWriter, matchID string, claims *middleware.MiniAppClaims) *services.MatchResponse {
    match, err := h.service.GetMatch(ctx, matchID)
    if err != nil {
        handleServiceError(ctx, w, err, "get match")
        return nil
    }

    if claims.ChatID == nil {
        httputil.RespondError(w, "chat context required", http.StatusForbidden)
        return nil
    }
    if *claims.ChatID != match.ChatID {
        httputil.RespondError(w, "access denied to this chat", http.StatusForbidden)
        return nil
    }

    return match
}
```

## Error Responses

- `403 Forbidden` - "chat context required" (JWT missing chat_id)
- `403 Forbidden` - "access denied to this chat" (match belongs to different chat)
- `404 Not Found` - "match not found" (match doesn't exist)

## Endpoints Already Secure (No Changes Needed)

These endpoints already properly validate chat_id via `parseChatIDWithAuth`:
- `HandleListMatches`
- `HandleGetUserActiveMatch`
- `HandleCreateMatch`
- `HandleGetMatch`
- `HandleGetLeaderboard`
- `HandleGetHistory`
- `HandleGetH2H`
- `HandleGetProfile`

## Test Plan

- [x] Code compiles without errors
- [x] Existing unit tests pass
- [ ] Manual testing: User with JWT for chat A cannot access match in chat B (should get 403)
- [ ] Manual testing: User with JWT for chat A can access match in chat A (should get 200)
- [ ] Manual testing: Gallery image access is properly restricted to owning chat

## Breaking Changes

None. The `GalleryImageURLResponse` now includes a `chat_id` field, but this is additive and won't break existing clients.
