### PR TITLE
Victory Animation Refactor: Stacked Card Fan Layout

### DIFF
--- a/apps/arena-mini-app/src/components/battle/BattlePage.tsx
+++ b/apps/arena-mini-app/src/components/battle/BattlePage.tsx
@@ -620,26 +620,36 @@ export function BattlePage({
       {/* Celebration cards flying to center */}
       {celebrationCards && (
         <div className="victory-celebration-overlay">
-          <div className="victory-cards-container">
-            {celebrationCards.map((card, index) => (
-              <div
-                key={card.card_id}
-                className="victory-flying-card"
-                style={{ '--card-index': index } as React.CSSProperties}
-              >
-                <CompactCard
-                  imageUrl={card.card_image_url || ''}
-                  positions={card.placeholder_positions}
-                  currentStats={{
-                    atk: card.atk,
-                    hp: card.max_hp,
-                    maxHp: card.max_hp,
-                  }}
-                  cardName={card.name}
-                  cardId={card.card_id}
-                />
-              </div>
-            ))}
+          {/* Player name banner */}
+          <div className="victory-player-banner">
+            {battleData.winner_id === battleData.player_a_id
+              ? battleData.player_a_name
+              : battleData.player_b_name} Wins!
+          </div>
+
+          {/* Stacked cards container */}
+          <div className="victory-cards-stack">
+            {celebrationCards.map((card, index) => {
+              const position = index === 1 ? 'center' : index === 0 ? 'left' : 'right'
+              return (
+                <div
+                  key={card.card_id}
+                  className={`victory-flying-card victory-flying-card--${position}`}
+                >
+                  <CompactCard
+                    imageUrl={card.card_image_url || ''}
+                    positions={card.placeholder_positions}
+                    currentStats={{
+                      atk: card.atk,
+                      hp: card.max_hp,
+                      maxHp: card.max_hp,
+                    }}
+                    cardName={card.name}
+                    cardId={card.card_id}
+                  />
+                </div>
+              )
+            })}
           </div>
         </div>
       )}

--- a/apps/arena-mini-app/src/styles/global.css
+++ b/apps/arena-mini-app/src/styles/global.css
@@ -2676,7 +2676,7 @@ a:focus:not(:focus-visible),
 }
 
 /* -----------------------------------------------------------------------------
-   Victory Celebration Cards (Flying to Center)
+   Victory Celebration Cards (Stacked Fan Layout)
    ----------------------------------------------------------------------------- */
 
 /* Victory celebration overlay - covers entire viewport */
@@ -2684,35 +2684,108 @@ a:focus:not(:focus-visible),
   position: fixed;
   inset: 0;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 20px;
   pointer-events: none;
   z-index: 90; /* Below particles (100) but above arena */
 }
 
-/* Container for the 3 victory cards */
-.victory-cards-container {
-  display: flex;
-  gap: 16px;
+/* Player name banner with golden glow */
+.victory-player-banner {
+  font-size: clamp(18px, 5vw, 28px);
+  font-weight: 800;
+  color: #FFD700;
+  text-shadow:
+    0 0 10px rgba(255, 215, 0, 0.8),
+    0 0 20px rgba(255, 165, 0, 0.6),
+    0 2px 4px rgba(0, 0, 0, 0.8);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  animation: banner-fade-in 0.4s ease-out forwards,
+             banner-glow 1.5s ease-in-out 0.4s infinite;
+  opacity: 0;
+}
+
+@keyframes banner-fade-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes banner-glow {
+  0%, 100% {
+    text-shadow:
+      0 0 10px rgba(255, 215, 0, 0.8),
+      0 0 20px rgba(255, 165, 0, 0.6),
+      0 2px 4px rgba(0, 0, 0, 0.8);
+  }
+  50% {
+    text-shadow:
+      0 0 15px rgba(255, 215, 0, 1),
+      0 0 30px rgba(255, 165, 0, 0.8),
+      0 0 45px rgba(255, 215, 0, 0.5),
+      0 2px 4px rgba(0, 0, 0, 0.8);
+  }
+}
+
+/* Stacked cards container - positioned relative for absolute children */
+.victory-cards-stack {
+  position: relative;
+  width: clamp(140px, 45vw, 200px);
+  aspect-ratio: 2/3;
   transform-style: preserve-3d;
   perspective: 1000px;
 }
 
-/* Individual flying card wrapper */
+/* Individual flying card wrapper - absolute positioning for stacking */
 .victory-flying-card {
-  /* Custom properties for responsive scaling */
-  --victory-scale: 0.6;
-  --victory-scale-pulse: 0.65;
-  --victory-rotation: 5deg;
-
-  animation: fly-to-center 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards,
-             victory-pulse 1.5s ease-in-out 0.6s infinite;
-  /* Stagger animation based on card index */
-  animation-delay: calc(var(--card-index) * 0.1s), calc(0.6s + var(--card-index) * 0.1s);
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   opacity: 0;
-  transform: scale(0.3);
 }
 
+/* Scale down compact cards to fit stack container */
+.victory-flying-card .compact-card {
+  width: 100%;
+  height: 100%;
+  box-shadow:
+    0 0 20px rgba(255, 215, 0, 0.5),
+    0 0 40px rgba(255, 165, 0, 0.3),
+    0 0 60px rgba(255, 215, 0, 0.2);
+}
+
+/* Center card - prominent, front layer */
+.victory-flying-card--center {
+  z-index: 3;
+  animation: fly-to-center 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 0.1s forwards,
+             center-pulse 1.5s ease-in-out 0.6s infinite;
+}
+
+/* Left card - peeking from behind, rotated left */
+.victory-flying-card--left {
+  z-index: 2;
+  animation: fly-to-left 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 0.2s forwards,
+             peek-pulse-left 1.5s ease-in-out 0.7s infinite;
+}
+
+/* Right card - peeking from behind, rotated right */
+.victory-flying-card--right {
+  z-index: 2;
+  animation: fly-to-right 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 0.3s forwards,
+             peek-pulse-right 1.5s ease-in-out 0.8s infinite;
+}
+
+/* Center card fly-in animation */
 @keyframes fly-to-center {
   0% {
     opacity: 0;
@@ -2723,51 +2796,90 @@ a:focus:not(:focus-visible),
   }
   100% {
     opacity: 1;
-    transform: scale(var(--victory-scale)) translateY(0) rotate(calc((var(--card-index) - 1) * var(--victory-rotation)));
+    transform: scale(1) translateY(0);
   }
 }
 
-@keyframes victory-pulse {
+/* Left card fly-in with rotation and offset */
+@keyframes fly-to-left {
+  0% {
+    opacity: 0;
+    transform: scale(0.3) translateY(100px) translateX(-50px) rotate(-20deg);
+  }
+  50% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0.9;
+    transform: scale(0.85) translateX(-25%) rotate(-12deg);
+  }
+}
+
+/* Right card fly-in with rotation and offset */
+@keyframes fly-to-right {
+  0% {
+    opacity: 0;
+    transform: scale(0.3) translateY(100px) translateX(50px) rotate(20deg);
+  }
+  50% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0.9;
+    transform: scale(0.85) translateX(25%) rotate(12deg);
+  }
+}
+
+/* Center card pulse animation */
+@keyframes center-pulse {
   0%, 100% {
-    transform: scale(var(--victory-scale)) rotate(calc((var(--card-index) - 1) * var(--victory-rotation)));
+    transform: scale(1);
     filter: drop-shadow(0 0 15px rgba(255, 215, 0, 0.6));
   }
   50% {
-    transform: scale(var(--victory-scale-pulse)) rotate(calc((var(--card-index) - 1) * var(--victory-rotation)));
+    transform: scale(1.05);
     filter: drop-shadow(0 0 25px rgba(255, 215, 0, 0.9))
             drop-shadow(0 0 50px rgba(255, 165, 0, 0.6));
   }
 }
 
-/* Enhanced golden glow for celebration cards */
-.victory-flying-card .compact-card {
-  box-shadow:
-    0 0 20px rgba(255, 215, 0, 0.5),
-    0 0 40px rgba(255, 165, 0, 0.3),
-    0 0 60px rgba(255, 215, 0, 0.2);
+/* Left card subtle pulse */
+@keyframes peek-pulse-left {
+  0%, 100% {
+    transform: scale(0.85) translateX(-25%) rotate(-12deg);
+    filter: drop-shadow(0 0 10px rgba(255, 215, 0, 0.4));
+  }
+  50% {
+    transform: scale(0.88) translateX(-25%) rotate(-12deg);
+    filter: drop-shadow(0 0 18px rgba(255, 215, 0, 0.7));
+  }
 }
 
-/* Victory celebration responsive - tablets/larger phones (361-480px) */
+/* Right card subtle pulse */
+@keyframes peek-pulse-right {
+  0%, 100% {
+    transform: scale(0.85) translateX(25%) rotate(12deg);
+    filter: drop-shadow(0 0 10px rgba(255, 215, 0, 0.4));
+  }
+  50% {
+    transform: scale(0.88) translateX(25%) rotate(12deg);
+    filter: drop-shadow(0 0 18px rgba(255, 215, 0, 0.7));
+  }
+}
+
+/* Responsive adjustments for smaller screens */
 @media (max-width: 480px) {
-  .victory-cards-container {
+  .victory-celebration-overlay {
+    gap: 16px;
+  }
+}
+
+@media (max-width: 360px) {
+  .victory-celebration-overlay {
     gap: 12px;
   }
-  .victory-flying-card {
-    --victory-scale: 0.36;
-    --victory-scale-pulse: 0.40;
-    --victory-rotation: 4deg;
-  }
-}
-
-/* Victory celebration responsive - small phones (≤360px, fits 320px+) */
-@media (max-width: 360px) {
-  .victory-cards-container {
-    gap: 8px;
-  }
-  .victory-flying-card {
-    --victory-scale: 0.32;
-    --victory-scale-pulse: 0.35;
-    --victory-rotation: 3deg;
+  .victory-player-banner {
+    letter-spacing: 1px;
   }
 }
 


### PR DESCRIPTION
# Victory Animation Refactor: Stacked Card Fan Layout

## Problem

The current winning animation displays 3 cards in a horizontal row that overflows on mobile screens:
- 3 cards at 96-180px width + gaps = 300-550px total width
- Only the center card is visible on 320px mobile screens
- Player name is not shown during the flying card celebration

## Solution

Replace the horizontal row with a **stacked/overlapping card arrangement** where:
- Center card is prominent and fully visible
- Side cards peek from behind with rotation (-12deg, +12deg)
- Player name banner displayed prominently above the stack
- Total width: ~216px (fits all mobile screens including 320px)

### Visual Layout

```
        ╭─────────────────────╮
        │  "PlayerName Wins!" │  ← Golden glowing banner
        ╰─────────────────────╯
              ╱        ╲
           ┌──┴──┐  ┌──┴──┐
          ╱│     │  │     │╲
         ╱ │SIDE │  │SIDE │ ╲    ← Side cards rotated, peeking
        │  └─────┘  └─────┘  │
        │    ┌───────────┐   │
        │    │  CENTER   │   │   ← Center card prominent
        │    │   CARD    │   │
        │    └───────────┘   │
        ╰────────────────────╯
               [PARTICLES]
```

## Changes

### `src/components/battle/BattlePage.tsx`
- Added `victory-player-banner` showing winner's name
- Changed container from horizontal flex to stacked layout
- Added position-based classes (`--left`, `--center`, `--right`) for each card

### `src/styles/global.css`
- New column flex layout with banner above stacked cards
- Player name banner with golden glow and pulse animation
- Stacked cards container with `clamp(140px, 45vw, 200px)` width
- Position-specific fly-in animations with rotation and offset
- Separate pulse animations for each card position

## Width Calculations (Mobile-First)

| Viewport | Stack Width | Side Offset | Total Width | Margin |
|----------|-------------|-------------|-------------|--------|
| 320px    | 144px (45vw)| 36px each   | 216px       | 52px each |
| 375px    | 169px       | 42px each   | 253px       | 61px each |
| 480px+   | 200px (max) | 50px each   | 300px       | 90px each |

## Animation Timeline

| Time | Event |
|------|-------|
| 0ms | Player banner fades in |
| 100ms | Center card flies to center |
| 200ms | Left card flies in (staggered) |
| 300ms | Right card flies in (staggered) |
| 600ms | Particle burst begins |
| 600ms+ | All elements pulse with golden glow |
| 3500ms | Celebration ends, victory modal appears |

## Testing

1. **Mobile testing**: Open in Chrome DevTools, test at 320px, 360px, 375px widths
2. **Visual check**: All 3 cards should be visible at 320px minimum
3. **Player name**: Banner should show winner's name during celebration
4. **Animations**: Cards should fly in with stagger, pulse smoothly
5. **Particles**: Should emit from center of card stack
