### PR TITLE
Make Media Upload Configurable in Telegram Bot

### DIFF
--- a/apps/telegram-bot/cmd/main.go
+++ b/apps/telegram-bot/cmd/main.go
@@ -35,6 +35,7 @@ func main() {
 	slog.Info("starting telegram-bot",
 		"environment", cfg.Environment,
 		"api_service_url", cfg.APIServiceURL,
+		"media_upload_enabled", cfg.MediaUploadEnabled,
 	)
 
 	// Initialize New Relic APM (optional - continues without if fails)
@@ -66,7 +67,7 @@ func main() {
 	apiClient := client.NewAPIClient(cfg.APIServiceURL, cfg.APIKey, nrApp)
 
 	// Initialize handlers
-	updateHandler := handlers.NewUpdateHandler(apiClient, nrApp)
+	updateHandler := handlers.NewUpdateHandler(apiClient, nrApp, cfg.MediaUploadEnabled)
 	photoUpdateHandler := handlers.NewPhotoUpdateHandler(apiClient, cfg, nrApp)
 	meHandler := handlers.NewMeHandler(apiClient, nrApp)
 	criteriaHandler := handlers.NewCriteriaHandler(nrApp)

--- a/apps/telegram-bot/internal/handlers/update_handler.go
+++ b/apps/telegram-bot/internal/handlers/update_handler.go
@@ -18,18 +18,20 @@ import (
 )
 
 type UpdateHandler struct {
-	apiClient  *client.APIClient
-	httpClient *http.Client
-	nrApp      *newrelic.Application
+	apiClient          *client.APIClient
+	httpClient         *http.Client
+	nrApp              *newrelic.Application
+	mediaUploadEnabled bool
 }
 
-func NewUpdateHandler(apiClient *client.APIClient, nrApp *newrelic.Application) *UpdateHandler {
+func NewUpdateHandler(apiClient *client.APIClient, nrApp *newrelic.Application, mediaUploadEnabled bool) *UpdateHandler {
 	return &UpdateHandler{
 		apiClient: apiClient,
 		httpClient: &http.Client{
 			Timeout: internal.FileDownloadTimeout,
 		},
-		nrApp: nrApp,
+		nrApp:              nrApp,
+		mediaUploadEnabled: mediaUploadEnabled,
 	}
 }
 
@@ -96,21 +98,29 @@ func (h *UpdateHandler) Handle(ctx context.Context, b *bot.Bot, update *models.U
 		}
 	}
 
-	// Extract file IDs from the update
-	var fileIDs []string
-	if txn != nil {
-		segment := txn.StartSegment("extract-file-ids")
-		fileIDs = h.extractFileIDs(update)
-		segment.End()
-		txn.AddAttribute("file_count", len(fileIDs))
-	} else {
-		fileIDs = h.extractFileIDs(update)
-	}
+	// Extract file IDs and download media files (if enabled)
+	var files map[string][]byte
+	if h.mediaUploadEnabled {
+		var fileIDs []string
+		if txn != nil {
+			segment := txn.StartSegment("extract-file-ids")
+			fileIDs = h.extractFileIDs(update)
+			segment.End()
+			txn.AddAttribute("file_count", len(fileIDs))
+		} else {
+			fileIDs = h.extractFileIDs(update)
+		}
 
-	// Download all media files concurrently
-	files := h.downloadFiles(ctx, b, fileIDs)
-	if txn != nil {
-		txn.AddAttribute("files_downloaded", len(files))
+		// Download all media files concurrently
+		files = h.downloadFiles(ctx, b, fileIDs)
+		if txn != nil {
+			txn.AddAttribute("files_downloaded", len(files))
+		}
+	} else {
+		if txn != nil {
+			txn.AddAttribute("media_upload_enabled", false)
+		}
+		slog.Debug("media upload disabled, skipping file downloads", "update_id", update.ID)
 	}
 
 	// Send update to API service

--- a/infrastructure/.env.dev.example
+++ b/infrastructure/.env.dev.example
@@ -26,6 +26,9 @@ API_SERVICE_URL=http://api-service:8080
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 TELEGRAM_BOT_USERNAME=your_bot_username_without_at_sign
 ADMIN_USER_IDS=1234567890
+# Enable/disable media file upload to object storage
+# When false: message metadata is saved but media files are not downloaded/uploaded
+MEDIA_UPLOAD_ENABLED=false
 
 # =============================================================================
 # MINIO CONFIGURATION (Local Development)

--- a/infrastructure/.env.prod.example
+++ b/infrastructure/.env.prod.example
@@ -38,6 +38,9 @@ TIER_6=Random:10
 TELEGRAM_BOT_TOKEN=your_production_telegram_bot_token_here
 TELEGRAM_BOT_USERNAME=your_bot_username_without_at_sign
 ADMIN_USER_IDS=1234567890
+# Enable/disable media file upload to object storage
+# When false: message metadata is saved but media files are not downloaded/uploaded
+MEDIA_UPLOAD_ENABLED=false
 
 # =============================================================================
 # LINODE OBJECT STORAGE CONFIGURATION

--- a/infrastructure/docker-compose.dev.yml
+++ b/infrastructure/docker-compose.dev.yml
@@ -109,6 +109,8 @@ services:
       ARENA_BASE_URL: ${ARENA_BASE_URL}
       # Internal webhook server port
       WEBHOOK_PORT: 8081
+      # Media upload to object storage
+      MEDIA_UPLOAD_ENABLED: ${MEDIA_UPLOAD_ENABLED:-false}
     volumes:
       - ./secrets/apps/telegram-bot:/app/secrets:ro
     depends_on:

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -93,6 +93,8 @@ services:
       ARENA_BASE_URL: ${ARENA_BASE_URL}
       # Internal webhook server port
       WEBHOOK_PORT: 8081
+      # Media upload to object storage
+      MEDIA_UPLOAD_ENABLED: ${MEDIA_UPLOAD_ENABLED:-false}
     volumes:
       - ./secrets/apps/telegram-bot:/app/secrets:ro
     depends_on:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,8 @@ type Config struct {
 	APIServiceURL   string `envconfig:"API_SERVICE_URL" default:"http://api-service:8080"`
 
 	// Telegram Bot Configuration
-	TelegramBotToken string `envconfig:"TELEGRAM_BOT_TOKEN" required:"true"`
+	TelegramBotToken   string `envconfig:"TELEGRAM_BOT_TOKEN" required:"true"`
+	MediaUploadEnabled bool   `envconfig:"MEDIA_UPLOAD_ENABLED" default:"false"`
 
 	// MinIO Configuration
 	MinIOEndpoint  string `envconfig:"MINIO_ENDPOINT" default:"localhost:9000"`


### PR DESCRIPTION
# Make Media Upload Configurable in Telegram Bot

## Summary

Adds an environment variable `MEDIA_UPLOAD_ENABLED` to control whether the telegram-bot downloads and forwards media files to the API service. When disabled, message metadata is still sent (registering media references in the database), but actual file bytes are not downloaded or uploaded to object storage.

## Motivation

This allows running the bot in a lightweight mode where media files are not stored, reducing bandwidth usage and storage costs while still capturing all message metadata.

## Changes

### Go Code
- **`pkg/config/config.go`**: Added `MediaUploadEnabled` field (default: `false`)
- **`apps/telegram-bot/internal/handlers/update_handler.go`**: Conditionally skip file download when disabled
- **`apps/telegram-bot/cmd/main.go`**: Pass config to handler and log setting at startup

### Docker Compose
- **`infrastructure/docker-compose.dev.yml`**: Added `MEDIA_UPLOAD_ENABLED` env var
- **`infrastructure/docker-compose.prod.yml`**: Added `MEDIA_UPLOAD_ENABLED` env var

### Environment Files
- **`infrastructure/.env.dev`**: Added `MEDIA_UPLOAD_ENABLED=false`
- **`infrastructure/.env.prod`**: Added `MEDIA_UPLOAD_ENABLED=false`
- **`infrastructure/.env.dev.example`**: Added documented env var
- **`infrastructure/.env.prod.example`**: Added documented env var

## Behavior

| Setting | Metadata | Media Files |
|---------|----------|-------------|
| `MEDIA_UPLOAD_ENABLED=false` (default) | Sent to API | Not downloaded/uploaded |
| `MEDIA_UPLOAD_ENABLED=true` | Sent to API | Downloaded and uploaded |

## Test Plan

- [ ] Start services with default config (`MEDIA_UPLOAD_ENABLED=false`)
- [ ] Send a message with a photo to the bot
- [ ] Verify message is recorded in `messages` table
- [ ] Verify photo reference exists in `photos` table (with file_id from Telegram)
- [ ] Verify no file is uploaded to MinIO (`media_files` table empty or MinIO console)
- [ ] Check logs show "media upload disabled, skipping file downloads" message
- [ ] Set `MEDIA_UPLOAD_ENABLED=true` and restart
- [ ] Send another photo and verify it appears in object storage
