### PR TITLE
Battle Result DM Notifications

### DIFF
--- a/apps/api-service/internal/client/bot_client.go
+++ b/apps/api-service/internal/client/bot_client.go
@@ -41,6 +41,37 @@ type UpdateMatchMessageRequest struct {
 	TelegramMessageID int64  `json:"telegram_message_id"`
 }
 
+// BattleResultNotification is the request body for battle result DM notifications
+type BattleResultNotification struct {
+	MatchID   string `json:"match_id"`
+	ChatID    int64  `json:"chat_id"`
+	MatchType string `json:"match_type"` // "regular" or "ranked"
+	Format    string `json:"format"`     // "1v1" or "arena"
+
+	// 1v1 battle results
+	PlayerAID   int64  `json:"player_a_id"`
+	PlayerBID   int64  `json:"player_b_id"`
+	PlayerAName string `json:"player_a_name"`
+	PlayerBName string `json:"player_b_name"`
+	WinnerID    *int64 `json:"winner_id,omitempty"`
+	IsDraw      bool   `json:"is_draw"`
+	TeamADamage int    `json:"team_a_damage"`
+	TeamBDamage int    `json:"team_b_damage"`
+	NumRounds   int    `json:"num_rounds"`
+
+	// Arena tournament results (multi-player)
+	Participants []BattleParticipantResult `json:"participants,omitempty"`
+}
+
+// BattleParticipantResult represents a participant's tournament results
+type BattleParticipantResult struct {
+	UserID      int64  `json:"user_id"`
+	Name        string `json:"name"`
+	Wins        int    `json:"wins"`
+	TotalDamage int    `json:"total_damage"`
+	Rank        int    `json:"rank"`
+}
+
 // NotifyParticipantChange notifies the bot that a match participant has joined or left.
 // This triggers the bot to update the Telegram message with the new participant list.
 func (c *BotClient) NotifyParticipantChange(ctx context.Context, matchID string, chatID, telegramMessageID int64) error {
@@ -122,5 +153,77 @@ func (c *BotClient) NotifyParticipantChange(ctx context.Context, matchID string,
 	}
 
 	slog.Debug("notified bot of participant change", "match_id", matchID, "chat_id", chatID)
+	return nil
+}
+
+// NotifyBattleComplete notifies the bot to send DMs to players with battle results.
+// This is a best-effort notification - failures are logged but don't affect battle completion.
+func (c *BotClient) NotifyBattleComplete(ctx context.Context, notification *BattleResultNotification) error {
+	defer nrutil.StartSegment(ctx, "bot-client:notify-battle-complete")()
+
+	if c.baseURL == "" {
+		slog.Debug("bot client not configured, skipping battle result notification")
+		return nil
+	}
+
+	body, err := json.Marshal(notification)
+	if err != nil {
+		nrutil.NoticeError(ctx, err)
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	apiURL := c.baseURL + "/internal/notify-battle-result"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+	if err != nil {
+		nrutil.NoticeError(ctx, err)
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	// Track external HTTP call with detailed segment
+	txn := newrelic.FromContext(ctx)
+	var externalSegment *newrelic.ExternalSegment
+	if txn != nil {
+		parsedURL, _ := url.Parse(apiURL)
+		host := c.baseURL
+		if parsedURL != nil {
+			host = parsedURL.Host
+		}
+		externalSegment = &newrelic.ExternalSegment{
+			StartTime: txn.StartSegmentNow(),
+			URL:       apiURL,
+			Host:      host,
+			Procedure: "POST",
+			Library:   "net/http",
+		}
+		txn.AddAttribute("webhook_match_id", notification.MatchID)
+		txn.AddAttribute("webhook_format", notification.Format)
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+
+	if externalSegment != nil {
+		if resp != nil {
+			externalSegment.Response = resp
+		}
+		externalSegment.End()
+	}
+
+	if err != nil {
+		nrutil.NoticeError(ctx, err)
+		// Log but don't fail - this is a best-effort notification
+		slog.Warn("failed to notify bot of battle result", "match_id", notification.MatchID, "error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("bot returned non-OK status for battle result notification", "match_id", notification.MatchID, "status", resp.StatusCode)
+		return nil
+	}
+
+	slog.Debug("notified bot of battle result", "match_id", notification.MatchID, "format", notification.Format)
 	return nil
 }

--- a/apps/api-service/internal/services/battle_service.go
+++ b/apps/api-service/internal/services/battle_service.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 
 	"beef-briefing/apps/api-service/internal/apperror"
+	"beef-briefing/apps/api-service/internal/client"
 	"beef-briefing/apps/api-service/internal/game/battle"
 	"beef-briefing/apps/api-service/internal/jsonutil"
 	"beef-briefing/apps/api-service/internal/nrutil"
@@ -29,6 +31,7 @@ type BattleService struct {
 // BotClientInterface defines the interface for bot webhook notifications.
 type BotClientInterface interface {
 	NotifyParticipantChange(ctx context.Context, matchID string, chatID, telegramMessageID int64) error
+	NotifyBattleComplete(ctx context.Context, notification *client.BattleResultNotification) error
 }
 
 // NewBattleService creates a new BattleService instance.
@@ -285,6 +288,25 @@ func (s *BattleService) runBattle(ctx context.Context, matchID string, pA, pB *r
 		go s.botClient.NotifyParticipantChange(context.Background(), matchID, match.ChatID, *match.TelegramMessageID)
 	}
 
+	// Notify players via DM with battle results
+	if s.botClient != nil {
+		go s.botClient.NotifyBattleComplete(context.Background(), &client.BattleResultNotification{
+			MatchID:     matchID,
+			ChatID:      match.ChatID,
+			MatchType:   string(match.MatchType),
+			Format:      "1v1",
+			PlayerAID:   pA.UserID,
+			PlayerBID:   pB.UserID,
+			PlayerAName: ownerNameA,
+			PlayerBName: ownerNameB,
+			WinnerID:    result.WinnerID,
+			IsDraw:      result.IsDraw,
+			TeamADamage: result.TeamADamage,
+			TeamBDamage: result.TeamBDamage,
+			NumRounds:   result.NumRounds,
+		})
+	}
+
 	// Group events into combats
 	combats := battle.GroupEventsIntoCombats(result.Events, pA.UserID, pB.UserID)
 
@@ -368,10 +390,46 @@ func (s *BattleService) runArena(ctx context.Context, matchID string, participan
 	s.gameRepo.CompleteMatch(ctx, matchID, winnerID)
 
 	// Notify bot to update message with winner
+	match, err := s.gameRepo.GetMatch(ctx, matchID)
 	if s.botClient != nil {
-		match, err := s.gameRepo.GetMatch(ctx, matchID)
 		if err == nil && match != nil && match.TelegramMessageID != nil && *match.TelegramMessageID != 0 {
 			go s.botClient.NotifyParticipantChange(context.Background(), matchID, match.ChatID, *match.TelegramMessageID)
+		}
+
+		// Notify all participants via DM with tournament results
+		if err == nil && match != nil {
+			// Build ranked participant results
+			participantResults := make([]client.BattleParticipantResult, len(participants))
+			// Sort by wins desc, then damage desc, then user_id asc for ranking
+			sorted := make([]*repository.ParticipantWithUser, len(participants))
+			copy(sorted, participants)
+			sort.Slice(sorted, func(i, j int) bool {
+				if sorted[i].Wins != sorted[j].Wins {
+					return sorted[i].Wins > sorted[j].Wins
+				}
+				if sorted[i].TotalDamageDealt != sorted[j].TotalDamageDealt {
+					return sorted[i].TotalDamageDealt > sorted[j].TotalDamageDealt
+				}
+				return sorted[i].UserID < sorted[j].UserID
+			})
+			for i, p := range sorted {
+				participantResults[i] = client.BattleParticipantResult{
+					UserID:      p.UserID,
+					Name:        p.FirstName,
+					Wins:        p.Wins,
+					TotalDamage: p.TotalDamageDealt,
+					Rank:        i + 1,
+				}
+			}
+			go s.botClient.NotifyBattleComplete(context.Background(), &client.BattleResultNotification{
+				MatchID:      matchID,
+				ChatID:       match.ChatID,
+				MatchType:    string(match.MatchType),
+				Format:       "arena",
+				WinnerID:     winnerID,
+				NumRounds:    roundNumber,
+				Participants: participantResults,
+			})
 		}
 	}
 

--- a/apps/telegram-bot/cmd/main.go
+++ b/apps/telegram-bot/cmd/main.go
@@ -242,20 +242,22 @@ func startWebhookServer(ctx context.Context, webhookHandler *handlers.WebhookHan
 
 	mux := http.NewServeMux()
 
-	// Wrap with API key authentication middleware
-	authHandler := func(w http.ResponseWriter, r *http.Request) {
-		// Verify API key from Authorization header
-		auth := r.Header.Get("Authorization")
-		expectedAuth := "Bearer " + apiKey
-		if auth != expectedAuth {
-			slog.Warn("unauthorized webhook request", "remote_addr", r.RemoteAddr)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
+	// Auth middleware factory
+	withAuth := func(handler func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			expectedAuth := "Bearer " + apiKey
+			if auth != expectedAuth {
+				slog.Warn("unauthorized webhook request", "remote_addr", r.RemoteAddr, "path", r.URL.Path)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			handler(w, r)
 		}
-		webhookHandler.HandleUpdateMatchMessage(w, r)
 	}
 
-	mux.HandleFunc("/internal/update-match-message", authHandler)
+	mux.HandleFunc("/internal/update-match-message", withAuth(webhookHandler.HandleUpdateMatchMessage))
+	mux.HandleFunc("/internal/notify-battle-result", withAuth(webhookHandler.HandleBattleResultNotification))
 
 	// Health check endpoint (no auth required)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/apps/telegram-bot/internal/handlers/webhook_handler.go
+++ b/apps/telegram-bot/internal/handlers/webhook_handler.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -131,4 +133,216 @@ func (h *WebhookHandler) HandleUpdateMatchMessage(w http.ResponseWriter, r *http
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{"status":"ok"}`))
+}
+
+// BattleResultRequest is the request body for battle result DM notifications
+type BattleResultRequest struct {
+	MatchID   string `json:"match_id"`
+	ChatID    int64  `json:"chat_id"`
+	MatchType string `json:"match_type"` // "regular" or "ranked"
+	Format    string `json:"format"`     // "1v1" or "arena"
+
+	// 1v1 battle results
+	PlayerAID   int64  `json:"player_a_id"`
+	PlayerBID   int64  `json:"player_b_id"`
+	PlayerAName string `json:"player_a_name"`
+	PlayerBName string `json:"player_b_name"`
+	WinnerID    *int64 `json:"winner_id,omitempty"`
+	IsDraw      bool   `json:"is_draw"`
+	TeamADamage int    `json:"team_a_damage"`
+	TeamBDamage int    `json:"team_b_damage"`
+	NumRounds   int    `json:"num_rounds"`
+
+	// Arena tournament results (multi-player)
+	Participants []BattleParticipantResult `json:"participants,omitempty"`
+}
+
+// BattleParticipantResult represents a participant's tournament results
+type BattleParticipantResult struct {
+	UserID      int64  `json:"user_id"`
+	Name        string `json:"name"`
+	Wins        int    `json:"wins"`
+	TotalDamage int    `json:"total_damage"`
+	Rank        int    `json:"rank"`
+}
+
+// HandleBattleResultNotification handles POST /internal/notify-battle-result
+// This endpoint is called by the API service to send DMs to players after battle completion
+func (h *WebhookHandler) HandleBattleResultNotification(w http.ResponseWriter, r *http.Request) {
+	// Start New Relic transaction
+	var txn *newrelic.Transaction
+	if h.nrApp != nil {
+		txn = h.nrApp.StartTransaction("bot:webhook-battle-result")
+		defer txn.End()
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req BattleResultRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		slog.Error("failed to decode battle result request", "error", err)
+		if txn != nil {
+			txn.NoticeError(err)
+		}
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.MatchID == "" {
+		slog.Warn("battle result request missing match_id")
+		http.Error(w, "match_id is required", http.StatusBadRequest)
+		return
+	}
+
+	// Add attributes after parsing request
+	if txn != nil {
+		txn.AddAttribute("match_id", req.MatchID)
+		txn.AddAttribute("format", req.Format)
+	}
+
+	slog.Info("received battle result notification", "match_id", req.MatchID, "format", req.Format)
+
+	// Create context for sending DMs
+	ctx := r.Context()
+	if txn != nil {
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+
+	// Send DMs asynchronously based on format
+	if req.Format == "1v1" {
+		go h.send1v1ResultDMs(ctx, req)
+	} else if req.Format == "arena" {
+		go h.sendArenaResultDMs(ctx, req)
+	}
+
+	// Return success immediately (best-effort delivery)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`))
+}
+
+// send1v1ResultDMs sends battle result DMs to both players in a 1v1 match
+func (h *WebhookHandler) send1v1ResultDMs(ctx context.Context, req BattleResultRequest) {
+	// Send to Player A
+	go h.sendBattleResultDM(ctx, req.PlayerAID, h.build1v1Message(req, req.PlayerAID))
+
+	// Send to Player B
+	go h.sendBattleResultDM(ctx, req.PlayerBID, h.build1v1Message(req, req.PlayerBID))
+}
+
+// sendArenaResultDMs sends tournament result DMs to all participants
+func (h *WebhookHandler) sendArenaResultDMs(ctx context.Context, req BattleResultRequest) {
+	for _, p := range req.Participants {
+		go h.sendBattleResultDM(ctx, p.UserID, h.buildArenaMessage(req, p))
+	}
+}
+
+// sendBattleResultDM sends a single DM to a user with battle results
+func (h *WebhookHandler) sendBattleResultDM(ctx context.Context, userID int64, text string) {
+	_, err := h.bot.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:    userID,
+		Text:      text,
+		ParseMode: "Markdown",
+	})
+
+	if err != nil {
+		// Expected if user hasn't started chat with bot - log at debug level
+		slog.Debug("failed to send battle result DM", "user_id", userID, "error", err)
+	} else {
+		slog.Info("sent battle result DM", "user_id", userID)
+	}
+}
+
+// build1v1Message builds a DM message for a 1v1 battle result
+func (h *WebhookHandler) build1v1Message(req BattleResultRequest, userID int64) string {
+	isPlayerA := userID == req.PlayerAID
+	var opponentName string
+	var damageDealt, damageTaken int
+
+	if isPlayerA {
+		opponentName = req.PlayerBName
+		damageDealt = req.TeamADamage
+		damageTaken = req.TeamBDamage
+	} else {
+		opponentName = req.PlayerAName
+		damageDealt = req.TeamBDamage
+		damageTaken = req.TeamADamage
+	}
+
+	if req.IsDraw {
+		return fmt.Sprintf(`🤝 *Draw!*
+
+The battle with %s ended in a stalemate.
+
+📊 Battle Stats:
+• Your Damage: %d
+• Opponent Damage: %d
+• Combat Rounds: %d
+
+🎫 Match: %s`, opponentName, damageDealt, damageTaken, req.NumRounds, req.MatchID[:8])
+	}
+
+	isWinner := req.WinnerID != nil && *req.WinnerID == userID
+
+	if isWinner {
+		return fmt.Sprintf(`🏆 *Victory!*
+
+You defeated %s!
+
+📊 Battle Stats:
+• Damage Dealt: %d
+• Damage Taken: %d
+• Combat Rounds: %d
+
+🎫 Match: %s`, opponentName, damageDealt, damageTaken, req.NumRounds, req.MatchID[:8])
+	}
+
+	return fmt.Sprintf(`💀 *Defeat*
+
+%s emerged victorious.
+
+📊 Battle Stats:
+• Damage Dealt: %d
+• Damage Taken: %d
+• Combat Rounds: %d
+
+Better luck next time!
+
+🎫 Match: %s`, opponentName, damageDealt, damageTaken, req.NumRounds, req.MatchID[:8])
+}
+
+// buildArenaMessage builds a DM message for an arena tournament result
+func (h *WebhookHandler) buildArenaMessage(req BattleResultRequest, participant BattleParticipantResult) string {
+	isWinner := req.WinnerID != nil && *req.WinnerID == participant.UserID
+
+	if isWinner {
+		return fmt.Sprintf(`🏆 *Tournament Champion!*
+
+You won the arena tournament!
+
+🎖️ Your Record: %d wins, %d damage
+⚔️ Total Rounds: %d
+
+🎫 Match: %s`, participant.Wins, participant.TotalDamage, req.NumRounds, req.MatchID[:8])
+	}
+
+	// Find winner name
+	var winnerName string
+	for _, p := range req.Participants {
+		if req.WinnerID != nil && p.UserID == *req.WinnerID {
+			winnerName = p.Name
+			break
+		}
+	}
+
+	return fmt.Sprintf(`⚔️ *Tournament Complete*
+
+%s won the tournament!
+
+🎖️ Your Record: %d wins, %d damage (#%d)
+⚔️ Total Rounds: %d
+
+🎫 Match: %s`, winnerName, participant.Wins, participant.TotalDamage, participant.Rank, req.NumRounds, req.MatchID[:8])
 }


### PR DESCRIPTION
# 

## Summary
Implements automatic DM notifications to players after arena battles complete. Both players (1v1) or all participants (arena tournaments) receive a personalized message with their battle results immediately after the match ends.

## Changes

### API Service
- **bot_client.go**: Added `BattleResultNotification` and `BattleParticipantResult` structs, plus `NotifyBattleComplete()` method following the existing `NotifyParticipantChange()` pattern
- **battle_service.go**: Extended `BotClientInterface`, added notification calls after `CompleteMatch()` in both `runBattle()` (1v1) and `runArena()` (tournaments)

### Telegram Bot
- **main.go**: Added `/internal/notify-battle-result` webhook route with auth middleware
- **webhook_handler.go**: Added `HandleBattleResultNotification()` handler and message builders for all battle outcome scenarios

## Message Examples

**Victory (1v1):**
```
🏆 *Victory!*

You defeated John!

📊 Battle Stats:
• Damage Dealt: 145
• Damage Taken: 87
• Combat Rounds: 12

🎫 Match: a1b2c3d4
```

**Defeat (1v1):**
```
💀 *Defeat*

John emerged victorious.

📊 Battle Stats:
• Damage Dealt: 87
• Damage Taken: 145
• Combat Rounds: 12

Better luck next time!

🎫 Match: a1b2c3d4
```

**Draw (1v1):**
```
🤝 *Draw!*

The battle with John ended in a stalemate.

📊 Battle Stats:
• Your Damage: 120
• Opponent Damage: 120
• Combat Rounds: 15

🎫 Match: a1b2c3d4
```

**Tournament Champion (Arena):**
```
🏆 *Tournament Champion!*

You won the arena tournament!

🎖️ Your Record: 3 wins, 450 damage
⚔️ Total Rounds: 6

🎫 Match: a1b2c3d4
```

**Tournament Participant (Arena):**
```
⚔️ *Tournament Complete*

John won the tournament!

🎖️ Your Record: 1 wins, 280 damage (#3)
⚔️ Total Rounds: 6

🎫 Match: a1b2c3d4
```

## Technical Details

- **Best-effort delivery**: DM failures don't affect battle completion
- **Non-blocking**: All notifications sent in goroutines with `context.Background()`
- **Silent failures**: Logged at DEBUG level (expected if user hasn't started chat with bot)
- **No retries**: Single attempt per notification (matches existing DM patterns)

## Test Plan
- [ ] Start a 1v1 match between two users
- [ ] Complete the battle and verify both users receive DMs
- [ ] Verify winner gets victory message, loser gets defeat message
- [ ] Test draw scenario (equal damage dealt)
- [ ] Test arena tournament (3+ players) and verify all participants receive DMs
- [ ] Verify DM failure doesn't break battle completion (test with user who hasn't started chat with bot)

