### PR TITLE
 Security Hardening: Mini App Authentication (#200)

### DIFF
--- a/apps/api-service/go.mod
+++ b/apps/api-service/go.mod
@@ -5,6 +5,7 @@ go 1.25
 require (
 	beef-briefing/pkg/config v0.0.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.10.9
 	github.com/minio/minio-go/v7 v7.0.82
@@ -17,7 +18,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect

--- a/apps/api-service/internal/handlers/mini_app_handler_test.go
+++ b/apps/api-service/internal/handlers/mini_app_handler_test.go
@@ -355,7 +355,7 @@ func TestHandleGameAuth_ExpiredTimestamp(t *testing.T) {
 		"chat_id":  int64(-1003280306634),
 		"user_id":  int64(12345),
 		"match_id": "match-abc-123",
-		"ts":       time.Now().Add(-25 * time.Hour).Unix(), // Expired timestamp
+		"ts":       time.Now().Add(-6 * time.Minute).Unix(), // Expired timestamp
 		"sig":      "some-signature",
 	}
 	bodyJSON, _ := json.Marshal(body)

--- a/apps/api-service/internal/middleware/jwt_auth.go
+++ b/apps/api-service/internal/middleware/jwt_auth.go
@@ -10,6 +10,7 @@ import (
 	"beef-briefing/apps/api-service/internal/httputil"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
@@ -46,6 +47,9 @@ func (a *JWTAuth) CreateToken(userID int64, chatID *int64, username *string, fir
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "beef-briefing-api",
+			Audience:  jwt.ClaimStrings{"beef-briefing-mini-app"},
+			ID:        uuid.New().String(),
 		},
 	}
 
@@ -60,7 +64,10 @@ func (a *JWTAuth) ValidateToken(tokenString string) (*MiniAppClaims, error) {
 			return nil, jwt.ErrSignatureInvalid
 		}
 		return a.secretKey, nil
-	})
+	},
+		jwt.WithIssuer("beef-briefing-api"),
+		jwt.WithAudience("beef-briefing-mini-app"),
+	)
 
 	if err != nil {
 		return nil, err

--- a/apps/api-service/internal/middleware/jwt_auth_test.go
+++ b/apps/api-service/internal/middleware/jwt_auth_test.go
@@ -1,0 +1,161 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestCreateToken_ContainsStandardClaims(t *testing.T) {
+	auth := NewJWTAuth("test-secret-key")
+
+	chatID := int64(-1001234567890)
+	username := "testuser"
+	tokenString, err := auth.CreateToken(12345, &chatID, &username, "TestUser")
+	if err != nil {
+		t.Fatalf("failed to create token: %v", err)
+	}
+
+	// Parse without validation to inspect claims
+	claims := &MiniAppClaims{}
+	_, err = jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		return []byte("test-secret-key"), nil
+	})
+	if err != nil {
+		t.Fatalf("failed to parse token: %v", err)
+	}
+
+	if claims.Issuer != "beef-briefing-api" {
+		t.Errorf("expected issuer 'beef-briefing-api', got '%s'", claims.Issuer)
+	}
+
+	audiences, err := claims.GetAudience()
+	if err != nil {
+		t.Fatalf("failed to get audience: %v", err)
+	}
+	if len(audiences) != 1 || audiences[0] != "beef-briefing-mini-app" {
+		t.Errorf("expected audience ['beef-briefing-mini-app'], got %v", audiences)
+	}
+
+	if claims.ID == "" {
+		t.Error("expected non-empty jti claim")
+	}
+}
+
+func TestValidateToken_RejectsWrongIssuer(t *testing.T) {
+	auth := NewJWTAuth("test-secret-key")
+
+	// Forge a token with wrong issuer
+	claims := MiniAppClaims{
+		UserID:    12345,
+		FirstName: "TestUser",
+		Type:      "mini_app",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "wrong-issuer",
+			Audience:  jwt.ClaimStrings{"beef-briefing-mini-app"},
+			ID:        "some-jti",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("test-secret-key"))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	_, err = auth.ValidateToken(tokenString)
+	if err == nil {
+		t.Fatal("expected error for wrong issuer, got nil")
+	}
+}
+
+func TestValidateToken_RejectsWrongAudience(t *testing.T) {
+	auth := NewJWTAuth("test-secret-key")
+
+	// Forge a token with wrong audience
+	claims := MiniAppClaims{
+		UserID:    12345,
+		FirstName: "TestUser",
+		Type:      "mini_app",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "beef-briefing-api",
+			Audience:  jwt.ClaimStrings{"wrong-audience"},
+			ID:        "some-jti",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("test-secret-key"))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	_, err = auth.ValidateToken(tokenString)
+	if err == nil {
+		t.Fatal("expected error for wrong audience, got nil")
+	}
+}
+
+func TestValidateToken_RejectsMissingIssuer(t *testing.T) {
+	auth := NewJWTAuth("test-secret-key")
+
+	// Forge a token without issuer (old-format token)
+	claims := MiniAppClaims{
+		UserID:    12345,
+		FirstName: "TestUser",
+		Type:      "mini_app",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("test-secret-key"))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	_, err = auth.ValidateToken(tokenString)
+	if err == nil {
+		t.Fatal("expected error for missing issuer, got nil")
+	}
+}
+
+func TestCreateToken_UniqueJTI(t *testing.T) {
+	auth := NewJWTAuth("test-secret-key")
+
+	token1, err := auth.CreateToken(12345, nil, nil, "User1")
+	if err != nil {
+		t.Fatalf("failed to create token 1: %v", err)
+	}
+
+	token2, err := auth.CreateToken(12345, nil, nil, "User1")
+	if err != nil {
+		t.Fatalf("failed to create token 2: %v", err)
+	}
+
+	// Parse both tokens to extract jti
+	claims1 := &MiniAppClaims{}
+	jwt.ParseWithClaims(token1, claims1, func(token *jwt.Token) (interface{}, error) {
+		return []byte("test-secret-key"), nil
+	})
+
+	claims2 := &MiniAppClaims{}
+	jwt.ParseWithClaims(token2, claims2, func(token *jwt.Token) (interface{}, error) {
+		return []byte("test-secret-key"), nil
+	})
+
+	if claims1.ID == "" || claims2.ID == "" {
+		t.Fatal("expected non-empty jti claims")
+	}
+
+	if claims1.ID == claims2.ID {
+		t.Errorf("expected unique jti values, got same value: %s", claims1.ID)
+	}
+}

--- a/apps/api-service/internal/services/mini_app_service.go
+++ b/apps/api-service/internal/services/mini_app_service.go
@@ -24,6 +24,16 @@ import (
 	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
+const (
+	// gameSignatureMaxAge is the maximum age in seconds for game URL signatures (5 minutes).
+	// Game URLs are generated on-demand when a user clicks the arena button,
+	// so a short window is sufficient.
+	gameSignatureMaxAge = 300
+
+	// initDataMaxAge is the maximum age in seconds for Telegram Mini App init data (24 hours).
+	initDataMaxAge = 86400
+)
+
 // InitDataUser represents user data from Telegram init data
 type InitDataUser struct {
 	ID        int64   `json:"id"`
@@ -224,7 +234,7 @@ func (s *MiniAppService) ValidateInitData(initData string, maxAgeSeconds int64) 
 // ValidateGameSignature validates a Games API signature for arena authentication.
 // The signature is an HMAC-SHA256 hash of the data string using the bot token as the key.
 // Data format: "chat_id=%d&match_id=%s&ts=%d&user_id=%d" (alphabetically sorted keys)
-// Timestamp must be within 24 hours of current time.
+// Timestamp must be within 5 minutes of current time.
 func (s *MiniAppService) ValidateGameSignature(chatID, userID int64, matchID string, ts int64, sig string) error {
 	// Validate required parameters
 	if chatID == 0 {
@@ -249,7 +259,7 @@ func (s *MiniAppService) ValidateGameSignature(chatID, userID int64, matchID str
 	if timeDiff < 0 {
 		return apperror.ErrFutureGameTimestamp
 	}
-	if timeDiff > 86400 { // 24 hours in seconds
+	if timeDiff > gameSignatureMaxAge {
 		return apperror.ErrExpiredGameTimestamp
 	}
 
@@ -274,7 +284,7 @@ func (s *MiniAppService) ValidateGameSignature(chatID, userID int64, matchID str
 func (s *MiniAppService) Authenticate(ctx context.Context, initData string) (*AuthResponse, error) {
 	defer nrutil.StartSegment(ctx, "service:mini-app:authenticate")()
 
-	validated, err := s.ValidateInitData(initData, 86400) // 24 hours max age
+	validated, err := s.ValidateInitData(initData, initDataMaxAge)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/api-service/internal/services/mini_app_service_test.go
+++ b/apps/api-service/internal/services/mini_app_service_test.go
@@ -276,6 +276,21 @@ func TestAuthenticate_CreatesJWT(t *testing.T) {
 	if claims.ChatID == nil || *claims.ChatID != chatID {
 		t.Errorf("expected JWT claims chat_id %d, got %v", chatID, claims.ChatID)
 	}
+
+	// Verify standard JWT claims (iss, aud, jti)
+	if claims.Issuer != "beef-briefing-api" {
+		t.Errorf("expected issuer 'beef-briefing-api', got '%s'", claims.Issuer)
+	}
+	audiences, err := claims.GetAudience()
+	if err != nil {
+		t.Fatalf("failed to get audience: %v", err)
+	}
+	if len(audiences) != 1 || audiences[0] != "beef-briefing-mini-app" {
+		t.Errorf("expected audience ['beef-briefing-mini-app'], got %v", audiences)
+	}
+	if claims.ID == "" {
+		t.Error("expected non-empty jti claim")
+	}
 }
 
 // TestGetOverviewStats_ValidPeriod verifies that GetOverviewStats returns
@@ -963,7 +978,7 @@ func TestValidateGameSignature_InvalidSignature(t *testing.T) {
 }
 
 // TestValidateGameSignature_ExpiredTimestamp verifies that ValidateGameSignature
-// returns ErrExpiredGameTimestamp when the timestamp is older than 24 hours.
+// returns ErrExpiredGameTimestamp when the timestamp is older than 5 minutes.
 func TestValidateGameSignature_ExpiredTimestamp(t *testing.T) {
 	botToken := "test-bot-token-123456"
 	svc := newTestMiniAppService(testutil.NewMockMiniAppRepository(), nil, "test-jwt-secret", botToken)
@@ -971,7 +986,7 @@ func TestValidateGameSignature_ExpiredTimestamp(t *testing.T) {
 	chatID := int64(-1002345678901)
 	userID := int64(12345)
 	matchID := "match-abc123"
-	ts := time.Now().Unix() - 86401 // 24 hours + 1 second old
+	ts := time.Now().Unix() - 301 // 5 minutes + 1 second old
 	sig := generateValidGameSignature(botToken, chatID, userID, matchID, ts)
 
 	// Execute
@@ -1041,7 +1056,7 @@ func TestValidateGameSignature_TamperedParams(t *testing.T) {
 			chatID:      chatID,
 			userID:      userID,
 			matchID:     matchID,
-			ts:          ts + 100, // Different timestamp
+			ts:          ts - 100, // Different timestamp (still within valid window)
 			sig:         sig,
 			expectedErr: apperror.ErrInvalidGameSignature,
 		},
@@ -1060,5 +1075,44 @@ func TestValidateGameSignature_TamperedParams(t *testing.T) {
 				t.Errorf("expected %v for %s, got %v", tc.expectedErr, tc.name, err)
 			}
 		})
+	}
+}
+
+// TestValidateGameSignature_ValidWithin5Minutes verifies that a signature
+// with a 4-minute-old timestamp is accepted.
+func TestValidateGameSignature_ValidWithin5Minutes(t *testing.T) {
+	botToken := "test-bot-token-123456"
+	svc := newTestMiniAppService(testutil.NewMockMiniAppRepository(), nil, "test-jwt-secret", botToken)
+
+	chatID := int64(-1002345678901)
+	userID := int64(12345)
+	matchID := "match-abc123"
+	ts := time.Now().Unix() - 240 // 4 minutes old
+	sig := generateValidGameSignature(botToken, chatID, userID, matchID, ts)
+
+	err := svc.ValidateGameSignature(chatID, userID, matchID, ts, sig)
+	if err != nil {
+		t.Fatalf("expected no error for 4-minute-old signature, got %v", err)
+	}
+}
+
+// TestValidateGameSignature_ExpiredAfter5Minutes verifies that a signature
+// with a 5min+1s-old timestamp is rejected.
+func TestValidateGameSignature_ExpiredAfter5Minutes(t *testing.T) {
+	botToken := "test-bot-token-123456"
+	svc := newTestMiniAppService(testutil.NewMockMiniAppRepository(), nil, "test-jwt-secret", botToken)
+
+	chatID := int64(-1002345678901)
+	userID := int64(12345)
+	matchID := "match-abc123"
+	ts := time.Now().Unix() - 301 // 5 minutes + 1 second old
+	sig := generateValidGameSignature(botToken, chatID, userID, matchID, ts)
+
+	err := svc.ValidateGameSignature(chatID, userID, matchID, ts, sig)
+	if err == nil {
+		t.Fatal("expected error for 5min+1s-old signature, got nil")
+	}
+	if err != apperror.ErrExpiredGameTimestamp {
+		t.Errorf("expected ErrExpiredGameTimestamp, got %v", err)
 	}
 }


### PR DESCRIPTION
##  Security Hardening: Mini App Authentication (#200)

### Summary

- Reduce game URL signature replay window from 24 hours to 5 minutes — game URLs are generated on-demand, so a tight window is appropriate
- Add standard JWT claims (`iss`, `aud`, `jti`) per RFC 7519 best practices — prevents token confusion across services and enables future revocation
- Add issuer/audience validation on token parsing — rejects tokens not issued by `beef-briefing-api` for `beef-briefing-mini-app`
- Fix pre-existing bug in `TestValidateGameSignature_TamperedParams` where `ts + 100` produced a future timestamp instead of testing signature mismatch

### Backward Compatibility

Existing JWTs (without `iss`/`aud`) will fail validation after deploy. This is acceptable — both Mini App auth flows (initData and game URL) re-authenticate on every open, so users get a fresh JWT automatically. Max disruption: 24h until all old tokens expire naturally.

### Files Changed

| File | Change |
|------|--------|
| `apps/api-service/internal/middleware/jwt_auth.go` | Add `iss`, `aud`, `jti` claims to `CreateToken`; add issuer/audience validation to `ValidateToken` |
| `apps/api-service/internal/middleware/jwt_auth_test.go` | **New** — 5 tests for standard JWT claims and validation |
| `apps/api-service/internal/services/mini_app_service.go` | Named constants `gameSignatureMaxAge` (300s) and `initDataMaxAge` (86400s); use in validation |
| `apps/api-service/internal/services/mini_app_service_test.go` | Update expired timestamp tests (86401→301), add 5-min boundary tests, add iss/aud/jti assertions, fix tampered timestamp test |
| `apps/api-service/internal/handlers/mini_app_handler_test.go` | Update expired timestamp from -25h to -6min |
| `apps/api-service/go.mod` | `google/uuid` promoted from indirect to direct dependency |

### Security Posture (Audit Notes)

**Existing protections (already in place):**
- HMAC-SHA256 signature validation against bot token for both auth flows (initData + game URL)
- JWT tokens for subsequent API requests (HS256 signed)
- Chat access checks — JWT chat_id must match requested chat_id

**Hardened in this PR:**
- Game URL replay window: 24h → 5min
- Standard JWT claims prevent token confusion if other services share signing keys

**Accepted risks (mitigated by HMAC signing model):**
- No rate limiting on auth endpoints — attacker needs valid bot token to forge signatures
- No DB-level chat membership check — Telegram's HMAC signature already proves membership
- No JWT revocation — tokens expire in 24h; both flows issue fresh tokens on every app open

### Test Plan

- [x] `go test ./internal/middleware/...` — all 5 new JWT tests pass
- [x] `go test ./internal/services/...` — updated timestamp and boundary tests pass
- [x] `go test ./internal/handlers/...` — updated handler tests pass
- [x] `go test -race ./internal/middleware/...` — no race conditions

Closes #200 