### PR TITLE
Beta Groups Allowlist for Tournament Mode and Ranked Matches

### DIFF
--- a/apps/api-service/cmd/main.go
+++ b/apps/api-service/cmd/main.go
@@ -38,9 +38,13 @@ func main() {
 	// Setup logger
 	setupLogger(cfg)
 
+	// Parse beta groups
+	betaGroups := cfg.ParseBetaGroups()
+
 	slog.Info("starting api-service",
 		"environment", cfg.Environment,
 		"api_port", cfg.APIPort,
+		"beta_groups_count", len(betaGroups),
 	)
 
 	// Initialize New Relic APM (optional - continues without if not configured)
@@ -101,7 +105,7 @@ func main() {
 	}
 
 	// Setup HTTP router
-	router := setupRouter(db, minioClient, cfg, nrApp)
+	router := setupRouter(db, minioClient, cfg, nrApp, betaGroups)
 
 	// Create HTTP server
 	server := &http.Server{
@@ -185,7 +189,7 @@ func initDatabase(cfg *config.Config) (*sql.DB, error) {
 	return db, nil
 }
 
-func setupRouter(db *sql.DB, minioClient *storage.MinIOClient, cfg *config.Config, nrApp *newrelic.Application) *mux.Router {
+func setupRouter(db *sql.DB, minioClient *storage.MinIOClient, cfg *config.Config, nrApp *newrelic.Application, betaGroups map[int64]bool) *mux.Router {
 	router := mux.NewRouter()
 
 	// Health check endpoint - MUST be registered BEFORE auth middleware (unauthenticated)
@@ -260,7 +264,7 @@ func setupRouter(db *sql.DB, minioClient *storage.MinIOClient, cfg *config.Confi
 		}
 
 		// Arena game service and handler - now with botClient for battle completion notifications
-		arenaService := services.NewArenaService(db, minioClient, cardService, nrApp, botClient, nil)
+		arenaService := services.NewArenaService(db, minioClient, cardService, nrApp, botClient, nil, betaGroups)
 
 		arenaHandler = handlers.NewArenaHandler(arenaService, cfg, botClient)
 

--- a/apps/api-service/internal/apperror/errors.go
+++ b/apps/api-service/internal/apperror/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrNotCreator        = errors.New("only the match creator can perform this action")
 	ErrActiveMatchExists = errors.New("an active match already exists; please wait for it to complete before creating a new one")
 	ErrRoundNotFound     = errors.New("round not found")
+	ErrMatchFullNonBeta  = errors.New("this group is limited to 1v1 matches")
 )
 
 // Card and deck errors

--- a/apps/api-service/internal/handlers/arena_handler.go
+++ b/apps/api-service/internal/handlers/arena_handler.go
@@ -212,6 +212,10 @@ func handleServiceError(ctx context.Context, w http.ResponseWriter, err error, e
 	case apperror.ErrActiveMatchExists:
 		httputil.RespondError(w, "an active match already exists. Please wait for it to complete before creating a new one.", http.StatusBadRequest)
 
+	// Beta group restriction
+	case apperror.ErrMatchFullNonBeta:
+		httputil.RespondError(w, "this group is limited to 1v1 matches", http.StatusForbidden)
+
 	// Default: unknown error
 	default:
 		httputil.RespondError(w, fmt.Sprintf("failed to %s", errOperationName), http.StatusInternalServerError)
@@ -327,7 +331,13 @@ func (h *ArenaHandler) HandleGetConstants(w http.ResponseWriter, r *http.Request
 		txn.SetName("api:arena:constants")
 	}
 
-	// Just return the constants - no auth validation needed beyond JWT which is enforced by middleware
+	// Determine if this is a beta group from JWT claims
+	isBetaGroup := false
+	claims := middleware.GetClaimsFromContext(ctx)
+	if claims != nil && claims.ChatID != nil {
+		isBetaGroup = h.service.IsBetaGroup(*claims.ChatID)
+	}
+
 	constants := map[string]interface{}{
 		"costs": map[string]int{
 			"card":    shop.CardCost,
@@ -364,6 +374,7 @@ func (h *ArenaHandler) HandleGetConstants(w http.ResponseWriter, r *http.Request
 				"urgent":  "#ef4444",
 			},
 		},
+		"is_beta_group": isBetaGroup,
 	}
 
 	httputil.RespondJSON(w, constants, http.StatusOK)

--- a/apps/api-service/internal/handlers/arena_handler_test.go
+++ b/apps/api-service/internal/handlers/arena_handler_test.go
@@ -280,7 +280,7 @@ func TestCreateMatch_Returns400OnMissingChatID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -318,7 +318,7 @@ func TestCreateMatch_Returns400OnBadRequest(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -362,7 +362,7 @@ func TestCreateMatch_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -398,7 +398,7 @@ func TestCreateMatch_Returns403OnForbidden(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -446,7 +446,7 @@ func TestGetMatch_Returns404OnNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -499,7 +499,7 @@ func TestErrorResponse_JSONStructure(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -554,7 +554,7 @@ func TestListMatches_Returns200OnSuccess(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -595,7 +595,7 @@ func TestListMatches_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -617,7 +617,7 @@ func TestListMatches_Returns400OnMissingChatID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -653,7 +653,7 @@ func TestJoinMatch_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -677,7 +677,7 @@ func TestJoinMatch_Returns400OnMissingMatchID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -710,7 +710,7 @@ func TestJoinMatch_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -747,7 +747,7 @@ func TestLeaveMatch_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -771,7 +771,7 @@ func TestLeaveMatch_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -808,7 +808,7 @@ func TestStartMatch_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -832,7 +832,7 @@ func TestStartMatch_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -869,7 +869,7 @@ func TestGetShop_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -893,7 +893,7 @@ func TestGetShop_Returns400OnMissingMatchID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -926,7 +926,7 @@ func TestGetShop_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -963,7 +963,7 @@ func TestBuyCard_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -990,7 +990,7 @@ func TestBuyCard_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1024,7 +1024,7 @@ func TestBuyCard_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1064,7 +1064,7 @@ func TestReroll_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1088,7 +1088,7 @@ func TestReroll_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1125,7 +1125,7 @@ func TestUpgrade_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1152,7 +1152,7 @@ func TestUpgrade_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1186,7 +1186,7 @@ func TestUpgrade_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1226,7 +1226,7 @@ func TestSetOrder_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1253,7 +1253,7 @@ func TestSetOrder_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1291,7 +1291,7 @@ func TestSubmitTeam_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1315,7 +1315,7 @@ func TestSubmitTeam_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1352,7 +1352,7 @@ func TestGetBattle_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1376,7 +1376,7 @@ func TestGetBattle_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1410,7 +1410,7 @@ func TestHandleGetBattle_ReturnsDamageSummary(t *testing.T) {
 	// Setup services
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1568,7 +1568,7 @@ func TestGetLeaderboard_Returns200OnSuccess(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1613,7 +1613,7 @@ func TestGetLeaderboard_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1635,7 +1635,7 @@ func TestGetLeaderboard_UsesDefaultType(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1677,7 +1677,7 @@ func TestGetLeaderboard_Returns400OnMissingChatID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1722,7 +1722,7 @@ func TestGetLeaderboard_TypeRegular(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1762,7 +1762,7 @@ func TestGetLeaderboard_CustomPagination(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1808,7 +1808,7 @@ func TestGetLeaderboard_ResponseStructure(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1867,7 +1867,7 @@ func TestGetLeaderboard_AccessDenied(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1900,7 +1900,7 @@ func TestGetLeaderboard_EmptyLeaderboard(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1950,7 +1950,7 @@ func TestGetLeaderboard_LimitClamping(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -1996,7 +1996,7 @@ func TestGetConstants_Returns200OnSuccess(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2052,7 +2052,7 @@ func TestGetHistory_Returns200OnSuccess(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2099,7 +2099,7 @@ func TestGetHistory_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2125,7 +2125,7 @@ func TestGetProfile_Returns200OnSuccess(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2167,7 +2167,7 @@ func TestGetProfile_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2193,7 +2193,7 @@ func TestGetH2H_Returns200OnSuccess(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2235,7 +2235,7 @@ func TestGetH2H_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2257,7 +2257,7 @@ func TestGetH2H_Returns400OnMissingOpponentID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2293,7 +2293,7 @@ func TestShareResult_Returns401OnUnauthorized(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2317,7 +2317,7 @@ func TestShareResult_Returns400OnMissingMatchID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2350,7 +2350,7 @@ func TestShareResult_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2387,7 +2387,7 @@ func TestBotCreateMatch_Returns400OnMissingFields(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2412,7 +2412,7 @@ func TestBotCreateMatch_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2434,7 +2434,7 @@ func TestBotGetMatch_Returns400OnMissingMatchID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2456,7 +2456,7 @@ func TestBotGetMatch_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2479,7 +2479,7 @@ func TestBotJoinMatch_Returns400OnMissingUserID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2505,7 +2505,7 @@ func TestBotJoinMatch_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2529,7 +2529,7 @@ func TestBotLeaveMatch_Returns400OnMissingUserID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2555,7 +2555,7 @@ func TestBotStartMatch_Returns400OnMissingUserID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2581,7 +2581,7 @@ func TestBotGetPendingMatches_Returns200OnSuccess(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2612,7 +2612,7 @@ func TestBotAutoStartMatch_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2635,7 +2635,7 @@ func TestBotForceSubmitTeams_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2658,7 +2658,7 @@ func TestBotGetShareData_Returns400OnMissingMatchID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2680,7 +2680,7 @@ func TestBotGetShareData_Returns404OnMatchNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2707,7 +2707,7 @@ func TestBotGetTodayTournament_Returns400OnMissingChatID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2737,7 +2737,7 @@ func TestBotGetTodayTournament_Returns400OnMissingDate(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2767,7 +2767,7 @@ func TestBotGetTodayTournament_Returns200OnNoTournament(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2797,7 +2797,7 @@ func TestBotGetTournament_Returns400OnInvalidID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2819,7 +2819,7 @@ func TestBotGetTournament_Returns404OnNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2841,7 +2841,7 @@ func TestBotGetPendingAnnouncements_Returns200(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2870,7 +2870,7 @@ func TestBotAnnounceTournament_Returns400OnMissingFields(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2895,7 +2895,7 @@ func TestBotAnnounceTournament_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2917,7 +2917,7 @@ func TestBotJoinTournament_Returns400OnMissingFields(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2942,7 +2942,7 @@ func TestBotJoinTournament_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2964,7 +2964,7 @@ func TestBotJoinTournament_Returns404OnNoTournament(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -2989,7 +2989,7 @@ func TestBotLeaveTournament_Returns400OnMissingFields(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -3014,7 +3014,7 @@ func TestBotLeaveTournament_Returns400OnInvalidJSON(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -3036,7 +3036,7 @@ func TestBotLeaveTournament_Returns404OnNoTournament(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -3061,7 +3061,7 @@ func TestBotGetPendingClose_Returns200(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -3090,7 +3090,7 @@ func TestBotCloseTournament_Returns400OnInvalidID(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -3112,7 +3112,7 @@ func TestBotCloseTournament_Returns404OnNotFound(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -3134,7 +3134,7 @@ func TestBotGetPendingRounds_Returns200(t *testing.T) {
 
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
@@ -3245,7 +3245,7 @@ func TestGetShop_IncludesPlaceholderPositions(t *testing.T) {
 	// Setup services
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	// Create a match
 	match, err := arenaService.CreateMatch(context.Background(), chatID, user1ID)
@@ -3452,7 +3452,7 @@ func TestGetBattle_IncludesPlaceholderPositions(t *testing.T) {
 	// Setup services
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 
 	// Create a match
 	match, err := arenaService.CreateMatch(context.Background(), chatID, user1ID)

--- a/apps/api-service/internal/handlers/match_handler_test.go
+++ b/apps/api-service/internal/handlers/match_handler_test.go
@@ -22,7 +22,7 @@ func setupMatchTestHandler(t *testing.T) (*ArenaHandler, func()) {
 	tdb := testutil.SetupTestDB(t)
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
 	return handler, func() { testutil.TeardownTestDB(t, tdb) }

--- a/apps/api-service/internal/handlers/shop_handler_test.go
+++ b/apps/api-service/internal/handlers/shop_handler_test.go
@@ -22,7 +22,7 @@ func setupShopTestHandler(t *testing.T) (*ArenaHandler, func()) {
 	tdb := testutil.SetupTestDB(t)
 	mockMinIO := testutil.NewMockMinIOClient()
 	cardService := services.NewCardService(tdb.DB, mockMinIO, nil, nil)
-	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil)
+	arenaService := services.NewArenaService(tdb.DB, mockMinIO, cardService, nil, nil, nil, nil)
 	cfg := &config.Config{}
 	handler := NewArenaHandler(arenaService, cfg, nil)
 	return handler, func() { testutil.TeardownTestDB(t, tdb) }

--- a/apps/api-service/internal/handlers/tournament_handler.go
+++ b/apps/api-service/internal/handlers/tournament_handler.go
@@ -7,6 +7,8 @@ import (
 
 	"beef-briefing/apps/api-service/internal/apperror"
 	"beef-briefing/apps/api-service/internal/httputil"
+	"beef-briefing/apps/api-service/internal/repository"
+	"beef-briefing/apps/api-service/internal/services"
 
 	"github.com/gorilla/mux"
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -121,8 +123,11 @@ func (h *ArenaHandler) HandleBotGetPendingAnnouncements(w http.ResponseWriter, r
 		return
 	}
 
+	// Filter out non-beta groups from ranked tournament announcements
+	filtered := filterBetaGroupTournaments(tournaments, h.service)
+
 	httputil.RespondJSON(w, map[string]interface{}{
-		"tournaments": tournaments,
+		"tournaments": filtered,
 	}, http.StatusOK)
 }
 
@@ -331,8 +336,11 @@ func (h *ArenaHandler) HandleBotGetPendingClose(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Filter out non-beta groups from ranked tournament close
+	filtered := filterBetaGroupTournaments(tournaments, h.service)
+
 	httputil.RespondJSON(w, map[string]interface{}{
-		"tournaments": tournaments,
+		"tournaments": filtered,
 	}, http.StatusOK)
 }
 
@@ -400,4 +408,17 @@ func (h *ArenaHandler) HandleBotGetPendingRounds(w http.ResponseWriter, r *http.
 	httputil.RespondJSON(w, map[string]interface{}{
 		"tournaments": tournaments,
 	}, http.StatusOK)
+}
+
+// filterBetaGroupTournaments removes tournaments for non-beta groups
+func filterBetaGroupTournaments(tournaments []*repository.TournamentInfo, svc *services.ArenaService) []*repository.TournamentInfo {
+	filtered := make([]*repository.TournamentInfo, 0, len(tournaments))
+	for _, t := range tournaments {
+		if svc.IsBetaGroup(t.ChatID) {
+			filtered = append(filtered, t)
+		} else {
+			slog.Debug("skipping tournament for non-beta group", "chat_id", t.ChatID, "tournament_id", t.TournamentID)
+		}
+	}
+	return filtered
 }

--- a/apps/api-service/internal/services/arena_service.go
+++ b/apps/api-service/internal/services/arena_service.go
@@ -23,7 +23,6 @@ const (
 	JoinWindowDuration   = 5 * time.Minute
 )
 
-
 // ArenaService handles arena game logic
 type ArenaService struct {
 	db                *sql.DB
@@ -36,6 +35,7 @@ type ArenaService struct {
 	cardService       CardServiceInterface
 	nrApp             *newrelic.Application
 	botClient         BotClientInterface
+	betaGroups        map[int64]bool
 }
 
 // ArenaServiceDeps holds the dependencies for ArenaService.
@@ -46,7 +46,6 @@ type ArenaServiceDeps struct {
 	CardService   CardServiceInterface
 }
 
-
 // recordMatchEvent records a custom event for match lifecycle events.
 // eventType should be "created", "started", "completed", etc.
 func recordMatchEvent(nrApp *newrelic.Application, eventType string, matchID string, chatID int64, creatorID int64, matchType string) {
@@ -55,11 +54,11 @@ func recordMatchEvent(nrApp *newrelic.Application, eventType string, matchID str
 	}
 
 	params := map[string]interface{}{
-		"event_type":  eventType,
-		"match_id":    matchID,
-		"chat_id":     chatID,
-		"creator_id":  creatorID,
-		"match_type":  matchType,
+		"event_type": eventType,
+		"match_id":   matchID,
+		"chat_id":    chatID,
+		"creator_id": creatorID,
+		"match_type": matchType,
 	}
 
 	nrApp.RecordCustomEvent("arena.match.event", params)
@@ -75,11 +74,13 @@ func NewArenaService(
 	nrApp *newrelic.Application,
 	botClient BotClientInterface,
 	deps *ArenaServiceDeps,
+	betaGroups map[int64]bool,
 ) *ArenaService {
 	svc := &ArenaService{
-		db:        db,
-		nrApp:     nrApp,
-		botClient: botClient,
+		db:         db,
+		nrApp:      nrApp,
+		botClient:  botClient,
+		betaGroups: betaGroups,
 	}
 
 	if deps != nil {
@@ -109,6 +110,11 @@ func NewArenaService(
 	return svc
 }
 
+// IsBetaGroup checks if a chat ID is in the beta groups list
+func (s *ArenaService) IsBetaGroup(chatID int64) bool {
+	return s.betaGroups[chatID]
+}
+
 // MatchResponse represents a match with participant info
 type MatchResponse struct {
 	*repository.Match
@@ -118,14 +124,14 @@ type MatchResponse struct {
 
 // ShopAffordability represents what actions a player can afford
 type ShopAffordability struct {
-	CanBuy               bool    `json:"can_buy"`
-	CanReroll            bool    `json:"can_reroll"`
-	CanUpgrade           bool    `json:"can_upgrade"`
-	CanSubmit            bool    `json:"can_submit"`
-	BuyDisabledReason    *string `json:"buy_disabled_reason"`
-	RerollDisabledReason *string `json:"reroll_disabled_reason"`
+	CanBuy                bool    `json:"can_buy"`
+	CanReroll             bool    `json:"can_reroll"`
+	CanUpgrade            bool    `json:"can_upgrade"`
+	CanSubmit             bool    `json:"can_submit"`
+	BuyDisabledReason     *string `json:"buy_disabled_reason"`
+	RerollDisabledReason  *string `json:"reroll_disabled_reason"`
 	UpgradeDisabledReason *string `json:"upgrade_disabled_reason"`
-	SubmitDisabledReason *string `json:"submit_disabled_reason"`
+	SubmitDisabledReason  *string `json:"submit_disabled_reason"`
 }
 
 // EnhancedShopCard wraps ShopCard with affordability info
@@ -138,54 +144,54 @@ type EnhancedShopCard struct {
 // EnhancedTeamCard wraps Card with upgrade preview info
 type EnhancedTeamCard struct {
 	*battle.Card
-	CanUpgradeATK         bool    `json:"can_upgrade_atk"`
-	CanUpgradeHP          bool    `json:"can_upgrade_hp"`
+	CanUpgradeATK            bool    `json:"can_upgrade_atk"`
+	CanUpgradeHP             bool    `json:"can_upgrade_hp"`
 	UpgradeATKDisabledReason *string `json:"upgrade_atk_disabled_reason"`
 	UpgradeHPDisabledReason  *string `json:"upgrade_hp_disabled_reason"`
-	ATKIfUpgraded         int     `json:"atk_if_upgraded"`
-	HPIfUpgraded          int     `json:"hp_if_upgraded"`
-	MaxHPIfUpgraded       int     `json:"max_hp_if_upgraded"`
+	ATKIfUpgraded            int     `json:"atk_if_upgraded"`
+	HPIfUpgraded             int     `json:"hp_if_upgraded"`
+	MaxHPIfUpgraded          int     `json:"max_hp_if_upgraded"`
 }
 
 // EnhancedShopResponse is the full shop response with affordability and upgrade previews
 type EnhancedShopResponse struct {
-	MatchID              string                `json:"match_id"`
-	Status               string                `json:"status"`
-	Coins                int                   `json:"coins"`
-	Cards                []*EnhancedShopCard   `json:"cards"`
-	Team                 []*EnhancedTeamCard   `json:"team"`
-	TeamOrder            []int                 `json:"team_order"`
-	IsReady              bool                  `json:"is_ready"`
-	TeamSubmitted        bool                  `json:"team_submitted"`
-	Deadline             *time.Time            `json:"deadline,omitempty"`
-	TimeRemaining        int                   `json:"time_remaining_seconds"`
-	CanReroll            bool                  `json:"can_reroll"`
-	Affordability        ShopAffordability     `json:"affordability"`
+	MatchID       string              `json:"match_id"`
+	Status        string              `json:"status"`
+	Coins         int                 `json:"coins"`
+	Cards         []*EnhancedShopCard `json:"cards"`
+	Team          []*EnhancedTeamCard `json:"team"`
+	TeamOrder     []int               `json:"team_order"`
+	IsReady       bool                `json:"is_ready"`
+	TeamSubmitted bool                `json:"team_submitted"`
+	Deadline      *time.Time          `json:"deadline,omitempty"`
+	TimeRemaining int                 `json:"time_remaining_seconds"`
+	CanReroll     bool                `json:"can_reroll"`
+	Affordability ShopAffordability   `json:"affordability"`
 }
 
 // BattleResponse represents battle results in the format the frontend expects
 type BattleResponse struct {
-	MatchID     string               `json:"match_id"`
-	WinnerID    *int64               `json:"winner_id,omitempty"`
-	IsDraw      bool                 `json:"is_draw"`
-	Combats     []battle.Combat      `json:"combats"`
-	Events      []battle.BattleEvent `json:"events"`
-	NumCombats  int                  `json:"num_combats"`
-	NumRounds   int                  `json:"num_rounds"`
-	TeamADamage int                  `json:"team_a_damage"`
-	TeamBDamage int                  `json:"team_b_damage"`
-	DamageDealt int                  `json:"damage_dealt"`
-	DamageTaken int                  `json:"damage_taken"`
-	TeamAFinal  *battle.Team         `json:"team_a_final"`
-	TeamBFinal  *battle.Team         `json:"team_b_final"`
-	PlayerAID   int64                `json:"player_a_id"`
-	PlayerBID   int64                `json:"player_b_id"`
-	PlayerAName string               `json:"player_a_name"`
-	PlayerBName string               `json:"player_b_name"`
-	Format        string             `json:"format"`
-	BracketRounds []BracketRound     `json:"bracket_rounds,omitempty"`
-	Standings     []ArenaStanding    `json:"standings,omitempty"`
-	FfaRounds     []FfaRoundSummary  `json:"ffa_rounds,omitempty"`
+	MatchID       string               `json:"match_id"`
+	WinnerID      *int64               `json:"winner_id,omitempty"`
+	IsDraw        bool                 `json:"is_draw"`
+	Combats       []battle.Combat      `json:"combats"`
+	Events        []battle.BattleEvent `json:"events"`
+	NumCombats    int                  `json:"num_combats"`
+	NumRounds     int                  `json:"num_rounds"`
+	TeamADamage   int                  `json:"team_a_damage"`
+	TeamBDamage   int                  `json:"team_b_damage"`
+	DamageDealt   int                  `json:"damage_dealt"`
+	DamageTaken   int                  `json:"damage_taken"`
+	TeamAFinal    *battle.Team         `json:"team_a_final"`
+	TeamBFinal    *battle.Team         `json:"team_b_final"`
+	PlayerAID     int64                `json:"player_a_id"`
+	PlayerBID     int64                `json:"player_b_id"`
+	PlayerAName   string               `json:"player_a_name"`
+	PlayerBName   string               `json:"player_b_name"`
+	Format        string               `json:"format"`
+	BracketRounds []BracketRound       `json:"bracket_rounds,omitempty"`
+	Standings     []ArenaStanding      `json:"standings,omitempty"`
+	FfaRounds     []FfaRoundSummary    `json:"ffa_rounds,omitempty"`
 }
 
 // BracketRound represents a single round in a bracket tournament (e.g., "Semifinals", "Final")
@@ -398,6 +404,17 @@ func (s *ArenaService) JoinMatch(ctx context.Context, matchID string, userID int
 	// Check join deadline for regular matches
 	if match.JoinDeadline != nil && time.Now().After(*match.JoinDeadline) {
 		return nil, apperror.ErrMatchNotOpen
+	}
+
+	// Non-beta groups are limited to 1v1 matches
+	if !s.IsBetaGroup(match.ChatID) {
+		count, err := s.gameRepo.GetParticipantCount(ctx, matchID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get participant count: %w", err)
+		}
+		if count >= 2 {
+			return nil, apperror.ErrMatchFullNonBeta
+		}
 	}
 
 	// Add participant

--- a/apps/api-service/internal/services/arena_service_test.go
+++ b/apps/api-service/internal/services/arena_service_test.go
@@ -948,7 +948,7 @@ func TestCreateMatch_Success(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1014,7 +1014,7 @@ func TestCreateMatch_NotEnoughCards(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1050,7 +1050,7 @@ func TestCreateMatch_ActiveMatchExists(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1088,7 +1088,7 @@ func TestJoinMatch_Success(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1127,7 +1127,7 @@ func TestJoinMatch_NotOpen(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1168,7 +1168,7 @@ func TestStartMatch_Success(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1222,7 +1222,7 @@ func TestStartMatch_NotCreator(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1265,7 +1265,7 @@ func TestStartMatch_NotEnoughParticipants(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1307,7 +1307,7 @@ func TestGetShop_Success(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1446,7 +1446,7 @@ func TestGetShop_AfterTeamSubmitted(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1601,7 +1601,7 @@ func TestBuyCard_Success(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1743,7 +1743,7 @@ func TestBuyCard_NotEnoughCoins(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1842,7 +1842,7 @@ func TestBuyCard_TeamFull(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -1968,7 +1968,7 @@ func TestReroll_Success(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -2115,7 +2115,7 @@ func TestReroll_AfterPurchase(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -2205,7 +2205,7 @@ func TestSubmitTeam_Success(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -2432,7 +2432,7 @@ func TestExecuteBattle_1v1(t *testing.T) {
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, nil)
 
 	ctx := context.Background()
 
@@ -2713,11 +2713,12 @@ func TestExecuteBattle_Arena(t *testing.T) {
 	mockRepo := newMockGameRepository()
 	mockCards := newMockCardService(20)
 
+	// Beta group required for 3+ player matches
 	svc := NewArenaService(tdb.DB, mockMinIO, mockCards, nil, nil, &ArenaServiceDeps{
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, map[int64]bool{testChatID: true})
 
 	ctx := context.Background()
 
@@ -2987,11 +2988,12 @@ func TestExecuteBattle_Bracket(t *testing.T) {
 	mockRepo := newMockGameRepository()
 	mockCards := newMockCardService(25)
 
+	// Beta group required for 3+ player matches
 	svc := NewArenaService(tdb.DB, mockMinIO, mockCards, nil, nil, &ArenaServiceDeps{
 		GameRepo:      mockRepo,
 		StorageClient: mockMinIO,
 		CardService:   mockCards,
-	})
+	}, map[int64]bool{testChatID: true})
 
 	ctx := context.Background()
 
@@ -3188,4 +3190,122 @@ func TestExecuteBattle_Bracket(t *testing.T) {
 	// Log bracket summary
 	t.Logf("Bracket battle completed: %d rounds, winner: user %d",
 		len(rounds), *match.WinnerUserID)
+}
+
+// TestJoinMatch_NonBetaGroupRejects3rdPlayer tests that non-beta groups cannot have 3+ players
+func TestJoinMatch_NonBetaGroupRejects3rdPlayer(t *testing.T) {
+	tdb := setupArenaTestDB(t)
+	defer testutil.TeardownTestDB(t, tdb)
+	defer cleanupArenaTables(t, tdb)
+
+	seedTestCards(t, tdb, 15)
+	defer cleanupArenaTestData(t, tdb)
+
+	mockMinIO := testutil.NewMockMinIOClient()
+	mockRepo := newMockGameRepository()
+	mockCards := newMockCardService(15)
+
+	// No beta groups - empty map
+	svc := NewArenaService(tdb.DB, mockMinIO, mockCards, nil, nil, &ArenaServiceDeps{
+		GameRepo:      mockRepo,
+		StorageClient: mockMinIO,
+		CardService:   mockCards,
+	}, map[int64]bool{})
+
+	ctx := context.Background()
+
+	// Create match (creator auto-joins = 1 participant)
+	createResp, err := svc.CreateMatch(ctx, testChatID, testCreatorUserID)
+	if err != nil {
+		t.Fatalf("CreateMatch failed: %v", err)
+	}
+
+	// Join as 2nd player - should succeed
+	_, err = svc.JoinMatch(ctx, createResp.Match.ID, testJoinerUserID)
+	if err != nil {
+		t.Fatalf("JoinMatch (2nd player) failed: %v", err)
+	}
+
+	// Join as 3rd player - should fail for non-beta group
+	thirdUserID := int64(900000003)
+	_, err = svc.JoinMatch(ctx, createResp.Match.ID, thirdUserID)
+	if err == nil {
+		t.Fatal("expected error for 3rd player in non-beta group, got nil")
+	}
+
+	if !errors.Is(err, apperror.ErrMatchFullNonBeta) {
+		t.Errorf("expected apperror.ErrMatchFullNonBeta, got %v", err)
+	}
+}
+
+// TestJoinMatch_BetaGroupAllows3rdPlayer tests that beta groups can have 3+ players
+func TestJoinMatch_BetaGroupAllows3rdPlayer(t *testing.T) {
+	tdb := setupArenaTestDB(t)
+	defer testutil.TeardownTestDB(t, tdb)
+	defer cleanupArenaTables(t, tdb)
+
+	seedTestCards(t, tdb, 15)
+	defer cleanupArenaTestData(t, tdb)
+
+	mockMinIO := testutil.NewMockMinIOClient()
+	mockRepo := newMockGameRepository()
+	mockCards := newMockCardService(15)
+
+	// testChatID is in beta groups
+	betaGroups := map[int64]bool{testChatID: true}
+	svc := NewArenaService(tdb.DB, mockMinIO, mockCards, nil, nil, &ArenaServiceDeps{
+		GameRepo:      mockRepo,
+		StorageClient: mockMinIO,
+		CardService:   mockCards,
+	}, betaGroups)
+
+	ctx := context.Background()
+
+	// Create match (creator auto-joins = 1 participant)
+	createResp, err := svc.CreateMatch(ctx, testChatID, testCreatorUserID)
+	if err != nil {
+		t.Fatalf("CreateMatch failed: %v", err)
+	}
+
+	// Join as 2nd player
+	_, err = svc.JoinMatch(ctx, createResp.Match.ID, testJoinerUserID)
+	if err != nil {
+		t.Fatalf("JoinMatch (2nd player) failed: %v", err)
+	}
+
+	// Join as 3rd player - should succeed for beta group
+	thirdUserID := int64(900000003)
+	joinResp, err := svc.JoinMatch(ctx, createResp.Match.ID, thirdUserID)
+	if err != nil {
+		t.Fatalf("JoinMatch (3rd player) in beta group failed: %v", err)
+	}
+
+	if len(joinResp.Participants) != 3 {
+		t.Errorf("expected 3 participants, got %d", len(joinResp.Participants))
+	}
+}
+
+// TestIsBetaGroup tests the IsBetaGroup method
+func TestIsBetaGroup(t *testing.T) {
+	mockMinIO := testutil.NewMockMinIOClient()
+	mockCards := newMockCardService(0)
+
+	betaGroups := map[int64]bool{-1001234567890: true, -1009876543210: true}
+	svc := NewArenaService(nil, mockMinIO, mockCards, nil, nil, nil, betaGroups)
+
+	if !svc.IsBetaGroup(-1001234567890) {
+		t.Error("expected true for listed group")
+	}
+	if !svc.IsBetaGroup(-1009876543210) {
+		t.Error("expected true for listed group")
+	}
+	if svc.IsBetaGroup(-1005555555555) {
+		t.Error("expected false for unlisted group")
+	}
+
+	// nil beta groups
+	svc2 := NewArenaService(nil, mockMinIO, mockCards, nil, nil, nil, nil)
+	if svc2.IsBetaGroup(-1001234567890) {
+		t.Error("expected false for nil beta groups")
+	}
 }

--- a/apps/arena-mini-app/src/App.tsx
+++ b/apps/arena-mini-app/src/App.tsx
@@ -287,6 +287,7 @@ function App() {
           <StatsPage
             chatId={chatId}
             userId={userId}
+            isBetaGroup={gameConstants?.is_beta_group ?? false}
           />
         )
       default:

--- a/apps/arena-mini-app/src/__tests__/authFlow.test.tsx
+++ b/apps/arena-mini-app/src/__tests__/authFlow.test.tsx
@@ -90,6 +90,7 @@ const mockGameConstants = {
     warning: 30,
     colors: { safe: '#22c55e', warning: '#eab308', urgent: '#ef4444' },
   },
+  is_beta_group: false,
 }
 
 describe('Auth Flow', () => {

--- a/apps/arena-mini-app/src/components/lobby/LobbyPage.tsx
+++ b/apps/arena-mini-app/src/components/lobby/LobbyPage.tsx
@@ -428,7 +428,7 @@ export function LobbyPage({
                   ))}
                 </div>
                 <span className="participants-count">
-                  {activeMatch.participants?.length || 0} / {activeMatch.format === '1v1' ? '2' : '∞'}
+                  {activeMatch.participants?.length || 0} / {gameConstants?.is_beta_group ? '∞' : '2'}
                 </span>
               </div>
 
@@ -549,7 +549,7 @@ export function LobbyPage({
                               ))}
                             </div>
                             <span className="participants-count">
-                              {participantCount} / {match.format === '1v1' ? '2' : '∞'}
+                              {participantCount} / {gameConstants?.is_beta_group ? '∞' : '2'}
                             </span>
                           </div>
 

--- a/apps/arena-mini-app/src/components/stats/StatsPage.tsx
+++ b/apps/arena-mini-app/src/components/stats/StatsPage.tsx
@@ -37,9 +37,10 @@ const PAGE_SIZE = 20
 interface StatsPageProps {
   chatId: number
   userId: number
+  isBetaGroup: boolean
 }
 
-export function StatsPage({ chatId, userId }: StatsPageProps) {
+export function StatsPage({ chatId, userId, isBetaGroup }: StatsPageProps) {
   // Sub-tab state
   const [activeSubTab, setActiveSubTab] = useState<StatsSubTab>('leaderboard')
 
@@ -388,23 +389,25 @@ export function StatsPage({ chatId, userId }: StatsPageProps) {
 
     return (
       <>
-        {/* Type toggle - outside the panel */}
-        <div className="rpg-type-toggle">
-          <GameButton
-            variant={leaderboardType === 'regular' ? 'primary' : 'neutral'}
-            size="sm"
-            onClick={() => handleLeaderboardTypeChange('regular')}
-          >
-            Casual
-          </GameButton>
-          <GameButton
-            variant={leaderboardType === 'ranked' ? 'primary' : 'neutral'}
-            size="sm"
-            onClick={() => handleLeaderboardTypeChange('ranked')}
-          >
-            Ranked
-          </GameButton>
-        </div>
+        {/* Type toggle - outside the panel (only show ranked option for beta groups) */}
+        {isBetaGroup && (
+          <div className="rpg-type-toggle">
+            <GameButton
+              variant={leaderboardType === 'regular' ? 'primary' : 'neutral'}
+              size="sm"
+              onClick={() => handleLeaderboardTypeChange('regular')}
+            >
+              Casual
+            </GameButton>
+            <GameButton
+              variant={leaderboardType === 'ranked' ? 'primary' : 'neutral'}
+              size="sm"
+              onClick={() => handleLeaderboardTypeChange('ranked')}
+            >
+              Ranked
+            </GameButton>
+          </div>
+        )}
 
         <RPGPanel variant="outer" className="stats-outer-panel">
           {/* Leaderboard list */}

--- a/apps/arena-mini-app/src/types/index.ts
+++ b/apps/arena-mini-app/src/types/index.ts
@@ -1203,6 +1203,8 @@ export interface GameConstants {
   hp_bar_thresholds: HpBarThresholds
   /** Countdown timer urgency thresholds */
   timer_thresholds: TimerThresholds
+  /** Whether this group has beta features (tournament mode, ranked matches) */
+  is_beta_group: boolean
 }
 
 // =============================================================================

--- a/apps/telegram-bot/cmd/main.go
+++ b/apps/telegram-bot/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -137,7 +138,11 @@ func main() {
 	if !rankedEnabled {
 		slog.Warn("ranked tournaments are globally disabled")
 	}
-	tournamentScheduler := scheduler.NewTournamentScheduler(apiClient, b, nrApp, rankedEnabled)
+	betaGroups := parseBetaGroups(os.Getenv("BETA_GROUPS"))
+	if len(betaGroups) > 0 {
+		slog.Info("beta groups configured", "count", len(betaGroups))
+	}
+	tournamentScheduler := scheduler.NewTournamentScheduler(apiClient, b, nrApp, rankedEnabled, betaGroups)
 	go tournamentScheduler.Start(ctx)
 
 	// Start internal webhook server for API service callbacks
@@ -231,6 +236,21 @@ func getEnvBool(name string, defaultVal bool) bool {
 		return defaultVal
 	}
 	return b
+}
+
+// parseBetaGroups parses a comma-separated string of chat IDs into a map
+func parseBetaGroups(s string) map[int64]bool {
+	result := make(map[int64]bool)
+	if s == "" {
+		return result
+	}
+	for _, idStr := range strings.Split(s, ",") {
+		idStr = strings.TrimSpace(idStr)
+		if id, err := strconv.ParseInt(idStr, 10, 64); err == nil {
+			result[id] = true
+		}
+	}
+	return result
 }
 
 // startWebhookServer starts the internal HTTP server for API service callbacks

--- a/apps/telegram-bot/internal/scheduler/tournament_scheduler.go
+++ b/apps/telegram-bot/internal/scheduler/tournament_scheduler.go
@@ -27,15 +27,17 @@ type TournamentScheduler struct {
 	bot           *bot.Bot
 	nrApp         *newrelic.Application
 	rankedEnabled bool
+	betaGroups    map[int64]bool
 }
 
 // NewTournamentScheduler creates a new tournament scheduler
-func NewTournamentScheduler(apiClient *client.APIClient, b *bot.Bot, nrApp *newrelic.Application, rankedEnabled bool) *TournamentScheduler {
+func NewTournamentScheduler(apiClient *client.APIClient, b *bot.Bot, nrApp *newrelic.Application, rankedEnabled bool, betaGroups map[int64]bool) *TournamentScheduler {
 	return &TournamentScheduler{
 		apiClient:     apiClient,
 		bot:           b,
 		nrApp:         nrApp,
 		rankedEnabled: rankedEnabled,
+		betaGroups:    betaGroups,
 	}
 }
 
@@ -104,6 +106,10 @@ func (s *TournamentScheduler) processAnnouncements(ctx context.Context, txn *new
 	}
 
 	for _, t := range tournaments {
+		if !s.betaGroups[t.ChatID] {
+			slog.Debug("skipping tournament announcement for non-beta group", "chat_id", t.ChatID)
+			continue
+		}
 		s.sendTournamentAnnouncement(ctx, t, txn)
 	}
 }
@@ -192,6 +198,10 @@ func (s *TournamentScheduler) processRegistrationClose(ctx context.Context, txn 
 	}
 
 	for _, t := range tournaments {
+		if !s.betaGroups[t.ChatID] {
+			slog.Debug("skipping tournament close for non-beta group", "chat_id", t.ChatID)
+			continue
+		}
 		s.closeTournament(ctx, t, txn)
 	}
 }

--- a/infrastructure/.env.dev.example
+++ b/infrastructure/.env.dev.example
@@ -52,6 +52,9 @@ LOG_LEVEL=debug
 # Ranked Tournaments Configuration
 RANKED_TOURNAMENTS_ENABLED=true
 
+# Beta Groups (comma-separated chat IDs with tournament mode and ranked matches)
+BETA_GROUPS=
+
 # Sound version for cache busting (bump when updating sound files)
 SOUND_VERSION=1
 

--- a/infrastructure/.env.prod.example
+++ b/infrastructure/.env.prod.example
@@ -64,6 +64,9 @@ LOG_LEVEL=info
 # Ranked Tournaments Configuration
 RANKED_TOURNAMENTS_ENABLED=true
 
+# Beta Groups (comma-separated chat IDs with tournament mode and ranked matches)
+BETA_GROUPS=
+
 # Sound version for cache busting (bump when updating sound files)
 SOUND_VERSION=1
 

--- a/infrastructure/docker-compose.dev.yml
+++ b/infrastructure/docker-compose.dev.yml
@@ -47,6 +47,7 @@ services:
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       CORS_ORIGINS: http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:6175
       ADMIN_USER_IDS: ${ADMIN_USER_IDS}
+      BETA_GROUPS: ${BETA_GROUPS:-}
       # Bot webhook for participant change notifications
       BOT_INTERNAL_URL: http://telegram-bot:8081
     ports:
@@ -111,6 +112,7 @@ services:
       WEBHOOK_PORT: 8081
       # Media upload to object storage
       MEDIA_UPLOAD_ENABLED: ${MEDIA_UPLOAD_ENABLED:-false}
+      BETA_GROUPS: ${BETA_GROUPS:-}
     volumes:
       - ./secrets/apps/telegram-bot:/app/secrets:ro
     depends_on:

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -46,6 +46,7 @@ services:
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       CORS_ORIGINS: https://leaderboard.${DOMAIN_NAME},https://deck.${DOMAIN_NAME},https://arena.${DOMAIN_NAME}
       ADMIN_USER_IDS: ${ADMIN_USER_IDS}
+      BETA_GROUPS: ${BETA_GROUPS:-}
       # Bot webhook for participant change notifications
       BOT_INTERNAL_URL: http://telegram-bot:8081
     volumes:
@@ -95,6 +96,7 @@ services:
       WEBHOOK_PORT: 8081
       # Media upload to object storage
       MEDIA_UPLOAD_ENABLED: ${MEDIA_UPLOAD_ENABLED:-false}
+      BETA_GROUPS: ${BETA_GROUPS:-}
     volumes:
       - ./secrets/apps/telegram-bot:/app/secrets:ro
     depends_on:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,8 +66,11 @@ type Config struct {
 	CORSOrigins string `envconfig:"CORS_ORIGINS"`
 
 	// Games API / Arena Configuration
-	ArenaBaseURL     string `envconfig:"ARENA_BASE_URL" default:"http://localhost:5175"`
+	ArenaBaseURL       string `envconfig:"ARENA_BASE_URL" default:"http://localhost:5175"`
 	ArenaGameShortName string `envconfig:"ARENA_GAME_SHORT_NAME" default:"arena"`
+
+	// Beta Groups Configuration
+	BetaGroups string `envconfig:"BETA_GROUPS"` // Comma-separated list of chat IDs with beta features
 }
 
 // DSN returns PostgreSQL connection string
@@ -99,6 +102,35 @@ func (c *Config) IsAdmin(userID int64) bool {
 	for _, idStr := range strings.Split(c.AdminUserIDs, ",") {
 		idStr = strings.TrimSpace(idStr)
 		if id, err := strconv.ParseInt(idStr, 10, 64); err == nil && id == userID {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseBetaGroups parses the BetaGroups comma-separated string into a map
+func (c *Config) ParseBetaGroups() map[int64]bool {
+	result := make(map[int64]bool)
+	if c.BetaGroups == "" {
+		return result
+	}
+	for _, idStr := range strings.Split(c.BetaGroups, ",") {
+		idStr = strings.TrimSpace(idStr)
+		if id, err := strconv.ParseInt(idStr, 10, 64); err == nil {
+			result[id] = true
+		}
+	}
+	return result
+}
+
+// IsBetaGroup checks if the given chat ID is in the beta groups list
+func (c *Config) IsBetaGroup(chatID int64) bool {
+	if c.BetaGroups == "" {
+		return false
+	}
+	for _, idStr := range strings.Split(c.BetaGroups, ",") {
+		idStr = strings.TrimSpace(idStr)
+		if id, err := strconv.ParseInt(idStr, 10, 64); err == nil && id == chatID {
 			return true
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,81 @@
+package config
+
+import "testing"
+
+func TestParseBetaGroups_Empty(t *testing.T) {
+	cfg := &Config{BetaGroups: ""}
+	result := cfg.ParseBetaGroups()
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+}
+
+func TestParseBetaGroups_Single(t *testing.T) {
+	cfg := &Config{BetaGroups: "-1001234567890"}
+	result := cfg.ParseBetaGroups()
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	if !result[-1001234567890] {
+		t.Error("expected -1001234567890 to be in map")
+	}
+}
+
+func TestParseBetaGroups_Multiple(t *testing.T) {
+	cfg := &Config{BetaGroups: "-1001234567890, -1009876543210, -1005555555555"}
+	result := cfg.ParseBetaGroups()
+	if len(result) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(result))
+	}
+	for _, id := range []int64{-1001234567890, -1009876543210, -1005555555555} {
+		if !result[id] {
+			t.Errorf("expected %d to be in map", id)
+		}
+	}
+}
+
+func TestParseBetaGroups_SkipsInvalid(t *testing.T) {
+	cfg := &Config{BetaGroups: "-1001234567890,invalid,-1009876543210"}
+	result := cfg.ParseBetaGroups()
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(result))
+	}
+}
+
+func TestIsBetaGroup_Empty(t *testing.T) {
+	cfg := &Config{BetaGroups: ""}
+	if cfg.IsBetaGroup(-1001234567890) {
+		t.Error("expected false for empty beta groups")
+	}
+}
+
+func TestIsBetaGroup_Match(t *testing.T) {
+	cfg := &Config{BetaGroups: "-1001234567890,-1009876543210"}
+	if !cfg.IsBetaGroup(-1001234567890) {
+		t.Error("expected true for listed group")
+	}
+	if !cfg.IsBetaGroup(-1009876543210) {
+		t.Error("expected true for listed group")
+	}
+}
+
+func TestIsBetaGroup_NoMatch(t *testing.T) {
+	cfg := &Config{BetaGroups: "-1001234567890,-1009876543210"}
+	if cfg.IsBetaGroup(-1005555555555) {
+		t.Error("expected false for unlisted group")
+	}
+}
+
+func TestIsAdmin_Empty(t *testing.T) {
+	cfg := &Config{AdminUserIDs: ""}
+	if cfg.IsAdmin(123) {
+		t.Error("expected false for empty admin list")
+	}
+}
+
+func TestIsAdmin_Match(t *testing.T) {
+	cfg := &Config{AdminUserIDs: "123,456"}
+	if !cfg.IsAdmin(123) {
+		t.Error("expected true for listed admin")
+	}
+}


### PR DESCRIPTION
## Beta Groups Allowlist for Tournament Mode and Ranked Matches

Closes #215

### Summary

- Add `BETA_GROUPS` env var (comma-separated chat IDs) to gate tournament mode (3+ players) and ranked daily matches behind an allowlist
- Non-allowlisted groups are limited to 1v1 casual matches only
- When `BETA_GROUPS` is empty/unset, no groups have access to these features (strictest default)

### What changed

**Backend gating (Go):**
- `pkg/config` — new `BetaGroups` field with `ParseBetaGroups()` and `IsBetaGroup()` methods
- `ArenaService.JoinMatch()` — rejects 3rd+ player for non-beta groups with `ErrMatchFullNonBeta` (403)
- Tournament handler — filters non-beta groups from `pending-announcements` and `pending-close` responses
- Tournament scheduler (telegram-bot) — skips announcements and registration close for non-beta groups
- Constants endpoint — returns `is_beta_group` boolean to frontend

**Frontend (React/TypeScript):**
- `GameConstants` type — added `is_beta_group` field
- `LobbyPage` — shows `/ 2` max players for non-beta groups, `/ ∞` for beta
- `StatsPage` — hides ranked/casual leaderboard toggle for non-beta groups (defaults to casual)

**Infrastructure:**
- Added `BETA_GROUPS` to `.env.dev.example`, `.env.prod.example`, and both docker-compose files (api-service + telegram-bot)

### Behavior

| Scenario | Beta Group | Non-Beta Group |
|----------|-----------|----------------|
| 1v1 matches | Allowed | Allowed |
| 3+ player join | Allowed | Rejected (403) |
| Ranked tournaments | Allowed (if DB flag also enabled) | Skipped |
| Ranked leaderboard toggle | Shown | Hidden |
| Constants `is_beta_group` | `true` | `false` |

### Configuration

```bash
# Enable beta features for specific groups
BETA_GROUPS=-1001234567890,-1009876543210
```

Works alongside the existing `RANKED_TOURNAMENTS_ENABLED` global kill switch and per-group `ranked_tournaments_enabled` DB flag — all three must align for ranked tournaments.

### Test plan

- [x] `pkg/config` — 9 tests for `ParseBetaGroups`/`IsBetaGroup` (empty, single, multiple, invalid, match/no-match)
- [x] `ArenaService` — `TestJoinMatch_NonBetaGroupRejects3rdPlayer`, `TestJoinMatch_BetaGroupAllows3rdPlayer`, `TestIsBetaGroup`
- [x] Existing multi-player tests (Arena/Bracket) updated to use beta groups
- [x] All 88 `NewArenaService()` call sites updated with new `betaGroups` parameter
- [x] Handler tests pass (`go test ./internal/handlers/... -count=1`)
- [x] Frontend builds (`pnpm run build`)
- [x] `go vet ./...` clean for api-service and telegram-bot
