### PR TITLE
Fix footer spacing when badges wrap to two lines

### DIFF
--- a/apps/card-renderer/templates/themes/blueprint/card.html
+++ b/apps/card-renderer/templates/themes/blueprint/card.html
@@ -306,8 +306,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -316,7 +316,7 @@
         .stat-card {
             background: rgba(255, 255, 255, 0.05);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 1px solid var(--border-color);
             transition: all 0.3s ease;
             position: relative;
@@ -334,7 +334,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -352,7 +352,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -407,7 +407,8 @@
             flex-wrap: wrap;
             gap: 6px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/clean/card.html
+++ b/apps/card-renderer/templates/themes/clean/card.html
@@ -306,8 +306,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -316,7 +316,7 @@
         .stat-card {
             background: rgba(255, 255, 255, 0.05);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 1px solid var(--border-color);
             transition: all 0.3s ease;
             position: relative;
@@ -334,7 +334,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -352,7 +352,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -407,7 +407,8 @@
             flex-wrap: wrap;
             gap: 6px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/gaming/card.html
+++ b/apps/card-renderer/templates/themes/gaming/card.html
@@ -306,8 +306,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -316,7 +316,7 @@
         .stat-card {
             background: rgba(255, 255, 255, 0.05);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 1px solid var(--border-color);
             transition: all 0.3s ease;
             position: relative;
@@ -334,7 +334,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -352,7 +352,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -407,7 +407,8 @@
             flex-wrap: wrap;
             gap: 6px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/meme/card.html
+++ b/apps/card-renderer/templates/themes/meme/card.html
@@ -310,8 +310,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -321,7 +321,7 @@
         .stat-card {
             background: rgba(255, 255, 255, 0.85);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 3px solid #000000;
             transition: all 0.3s ease;
             position: relative;
@@ -346,7 +346,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -365,7 +365,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -422,7 +422,8 @@
             flex-wrap: wrap;
             gap: 8px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/mythic/card.html
+++ b/apps/card-renderer/templates/themes/mythic/card.html
@@ -308,8 +308,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -319,7 +319,7 @@
         .stat-card {
             background: rgba(43, 29, 14, 0.6);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 1px solid rgba(245, 196, 107, 0.15);
             transition: all 0.3s ease;
             position: relative;
@@ -337,7 +337,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -355,7 +355,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -410,7 +410,8 @@
             flex-wrap: wrap;
             gap: 6px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/neon_arcade/card.html
+++ b/apps/card-renderer/templates/themes/neon_arcade/card.html
@@ -306,8 +306,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -316,7 +316,7 @@
         .stat-card {
             background: rgba(255, 255, 255, 0.05);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 1px solid var(--border-color);
             transition: all 0.3s ease;
             position: relative;
@@ -334,7 +334,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -352,7 +352,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -407,7 +407,8 @@
             flex-wrap: wrap;
             gap: 8px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/noir_luxury/card.html
+++ b/apps/card-renderer/templates/themes/noir_luxury/card.html
@@ -306,8 +306,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -316,7 +316,7 @@
         .stat-card {
             background: rgba(255, 255, 255, 0.05);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 1px solid var(--border-color);
             transition: all 0.3s ease;
             position: relative;
@@ -334,7 +334,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -352,7 +352,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -407,7 +407,8 @@
             flex-wrap: wrap;
             gap: 6px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/sticker/card.html
+++ b/apps/card-renderer/templates/themes/sticker/card.html
@@ -292,8 +292,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -303,7 +303,7 @@
         .stat-card {
             background: #ffffff;
             border-radius: 16px;
-            padding: 12px;
+            padding: 10px;
             border: none;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
             transition: all 0.3s ease;
@@ -322,7 +322,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -340,7 +340,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -395,7 +395,8 @@
             flex-wrap: wrap;
             gap: 8px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/sticker_retro/card.html
+++ b/apps/card-renderer/templates/themes/sticker_retro/card.html
@@ -292,8 +292,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -303,7 +303,7 @@
         .stat-card {
             background: #ffffff;
             border-radius: 16px;
-            padding: 12px;
+            padding: 10px;
             border: none;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
             transition: all 0.3s ease;
@@ -322,7 +322,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -340,7 +340,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -395,7 +395,8 @@
             flex-wrap: wrap;
             gap: 8px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }

--- a/apps/card-renderer/templates/themes/vaporwave/card.html
+++ b/apps/card-renderer/templates/themes/vaporwave/card.html
@@ -306,8 +306,8 @@
         .stats-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 12px;
-            margin-bottom: 20px;
+            gap: 10px;
+            margin-bottom: 16px;
             position: relative;
             z-index: 1;
             flex-shrink: 0;
@@ -316,7 +316,7 @@
         .stat-card {
             background: rgba(255, 255, 255, 0.05);
             border-radius: 12px;
-            padding: 12px;
+            padding: 10px;
             border: 1px solid var(--border-color);
             transition: all 0.3s ease;
             position: relative;
@@ -334,7 +334,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-icon {
@@ -352,7 +352,7 @@
             display: flex;
             align-items: baseline;
             gap: 8px;
-            margin-bottom: 4px;
+            margin-bottom: 2px;
         }
 
         .stat-value {
@@ -407,7 +407,8 @@
             flex-wrap: wrap;
             gap: 6px;
             margin-bottom: 12px;
-            margin-top: auto;
+            flex: 1;
+            align-content: flex-end;
             position: relative;
             z-index: 1;
         }


### PR DESCRIPTION
## Summary
Fixes footer spacing issue when user badges wrap to multiple lines.

Closes #226

## Changes
- Adjusted stat cards padding and margins (12px → 10px, 20px → 16px) to create more vertical space
- Modified badges container to use `flex: 1` and `align-content: flex-end`
- This ensures badges push to the bottom of their container while leaving adequate space for the footer
- Applied across all 10 card themes consistently

## Before
Footer text would get cut off/squeezed when badges wrapped to 2 lines (e.g., Regular + Hyperactive + Star + 55-day streak).

## After
Footer maintains proper spacing regardless of badge count/wrapping.

## Testing
- [x] Verified layout with single-line badges
- [x] Verified layout with two-line badges (multiple status + streak)
- [x] Checked all 10 themes for consistency