### PR TITLE
Add ML processor targets for batch processing all chats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,28 @@ ml-run-once-prod: | ensure-scripts-executable ## Run single batch (prod)
 ml-run-continuous-prod: | ensure-scripts-executable ## Run continuous processing (prod)
 	./scripts/ml-processor.sh --prod continuous $(ML_ARGS)
 
+ml-run-all: | ensure-scripts-executable ## Run ml-processor for ALL chats (dev)
+	./scripts/ml-processor.sh process-all $(ML_ARGS)
+
+ml-run-all-prod: | ensure-scripts-executable ## Run ml-processor for ALL chats (prod)
+	./scripts/ml-processor.sh --prod process-all $(ML_ARGS)
+
+ml-run-chat: | ensure-scripts-executable ## Run ml-processor for a single chat (dev). CHAT_ID required
+	@if [ -z "$(CHAT_ID)" ]; then \
+		echo "Error: CHAT_ID is required"; \
+		echo "Usage: make ml-run-chat CHAT_ID=-1003280306634 [ML_ARGS='--limit 100']"; \
+		exit 1; \
+	fi
+	./scripts/ml-processor.sh process --chat-id $(CHAT_ID) $(ML_ARGS)
+
+ml-run-chat-prod: | ensure-scripts-executable ## Run ml-processor for a single chat (prod). CHAT_ID required
+	@if [ -z "$(CHAT_ID)" ]; then \
+		echo "Error: CHAT_ID is required"; \
+		echo "Usage: make ml-run-chat-prod CHAT_ID=-1003280306634 [ML_ARGS='--limit 100']"; \
+		exit 1; \
+	fi
+	./scripts/ml-processor.sh --prod process --chat-id $(CHAT_ID) $(ML_ARGS)
+
 ml-run-cards-prod: | ensure-scripts-executable ## Generate weekly user cards (prod)
 	./scripts/ml-processor.sh --prod cards $(ML_ARGS)
 
@@ -972,6 +994,7 @@ mc-setup-prod: ## Configure MinIO Client alias for production
 	tf-connect tf-setup tf-sync-object-storage tf-update-ssh-config tf-docs tf-deploy-check \
 	ml-run ml-run-status ml-run-once ml-run-continuous ml-run-cards ml-run-render \
 	ml-run-render-regular ml-run-render-compact ml-run-render-all \
+	ml-run-all ml-run-all-prod ml-run-chat ml-run-chat-prod \
 	ml-run-prod ml-run-status-prod ml-run-once-prod ml-run-continuous-prod ml-run-cards-prod ml-run-render-prod \
 	ml-run-render-regular-prod ml-run-render-compact-prod ml-run-render-all-prod \
 	ml-shell ml-clean-dev ml-clean-prod ml-clean-cards-dev ml-clean-cards-prod \

--- a/apps/ml-processor/README.md
+++ b/apps/ml-processor/README.md
@@ -23,6 +23,12 @@ make up-build
 # Run batch processing (development)
 make ml-run
 
+# Process ALL chats (auto-discovers unprocessed)
+make ml-run-all
+
+# Dry run (list chats without processing)
+make ml-run-all ML_ARGS="--dry-run"
+
 # Check status
 make ml-run-status
 
@@ -93,10 +99,14 @@ Each analysis type can use a different provider:
 | Command | Description |
 |---------|-------------|
 | `make ml-run` | Run batch processing |
+| `make ml-run-all` | Process all chats with unprocessed messages |
+| `make ml-run-chat CHAT_ID=X` | Process a specific chat |
 | `make ml-run-once` | Process single batch |
 | `make ml-run-status` | Check processing status |
 | `make ml-run-continuous` | Run daemon mode |
 | `make ml-run-cards` | Generate weekly cards |
+| `make ml-run-all-prod` | Process all chats (prod, via SSH tunnel) |
+| `make ml-run-chat-prod CHAT_ID=X` | Process a specific chat (prod) |
 | `make ml-shell` | Open shell in container |
 
 ### Command Options
@@ -108,6 +118,7 @@ Each analysis type can use a different provider:
 --batch-size N            # Messages per batch
 --from-date D             # Process from date (YYYY-MM-DD)
 --to-date D               # Process until date (YYYY-MM-DD)
+--dry-run                 # List chats without processing (process-all only)
 
 # Cards options
 --timezone TZ             # IANA timezone (REQUIRED)
@@ -128,6 +139,16 @@ make ml-run ML_ARGS="--from-date 2025-01-01 --to-date 2025-01-07"
 
 # Generate cards for specific week
 make ml-run-cards ML_ARGS="--timezone America/Sao_Paulo --week 2025-01-06"
+
+# Dry run: see which chats have unprocessed messages
+make ml-run-all ML_ARGS="--dry-run"
+
+# Process all chats, max 500 messages each
+make ml-run-all ML_ARGS="--limit 500"
+
+# Process specific chat (shortcut — no need for ML_ARGS)
+make ml-run-chat CHAT_ID=-1003280306634
+make ml-run-chat CHAT_ID=-1003280306634 ML_ARGS="--limit 100"
 
 # Impersonation mode: read messages from dev group (-1001234567),
 # generate cards for production group (-1009876543)

--- a/apps/ml-processor/main.py
+++ b/apps/ml-processor/main.py
@@ -5,6 +5,7 @@ ML Processor - Analyzes Portuguese chat messages using local ML models.
 Usage:
     python main.py process --chat-id -1003280306634 [--limit N] [--batch-size N]
     python main.py process --chat-id -1003280306634 --from-date 2024-11-01 --to-date 2024-12-01
+    python main.py process-all [--dry-run] [--limit N] [--batch-size N]
     python main.py status --chat-id -1003280306634
     python main.py continuous --chat-id -1003280306634
 """
@@ -30,6 +31,7 @@ if _config.new_relic_enabled():
 # Now import everything else
 import argparse
 import logging
+import time
 from datetime import datetime
 
 from sqlalchemy import create_engine, text
@@ -182,6 +184,121 @@ def run_process(args, config):
         record_custom_metric("Custom/MLProcessor/TotalProcessed", total_processed)
         logger.info(f"Processing complete: {total_processed} total messages processed")
         return total_processed
+
+    finally:
+        processor.cleanup()
+
+
+def run_process_all(args, config):
+    """Run batch processing for all chats with unprocessed messages."""
+    logger.info("Discovering chats with unprocessed messages...")
+
+    batch_size = args.batch_size if args.batch_size is not None else config.batch_size
+    from_date = parse_date(getattr(args, "from_date", None))
+    to_date = parse_date(getattr(args, "to_date", None))
+
+    add_custom_attributes(
+        {
+            "command": "process-all",
+            "batch_size": batch_size,
+            "limit": args.limit,
+            "dry_run": args.dry_run,
+            "from_date": str(from_date.date()) if from_date else None,
+            "to_date": str(to_date.date()) if to_date else None,
+        }
+    )
+
+    # Create processor once (loads GPU models, connects to Qdrant)
+    processor = create_processor(config)
+    processor.setup()
+
+    try:
+        # Discover chats
+        chats = processor.queries.get_chat_ids_with_unprocessed(
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        if not chats:
+            logger.info("No chats with unprocessed messages found")
+            print("\nNo chats with unprocessed messages.")
+            return 0
+
+        # Print discovery results
+        total_unprocessed = sum(c["unprocessed_count"] for c in chats)
+        print(f"\nFound {len(chats)} chat(s) with {total_unprocessed:,} unprocessed messages:\n")
+        for i, chat in enumerate(chats, 1):
+            title = chat["chat_title"] or "Unknown"
+            print(f"  {i}. {chat['chat_id']} ({title}): {chat['unprocessed_count']:,} messages")
+
+        if args.dry_run:
+            print("\n--dry-run: exiting without processing.")
+            return 0
+
+        # Log configured providers
+        logger.info(f"Sentiment provider: {config.sentiment_provider}")
+        logger.info(f"Toxicity provider: {config.toxicity_provider}")
+        logger.info(f"Topics provider: {config.topics_provider}")
+        logger.info(f"NER provider: {config.ner_provider}")
+
+        # Process each chat
+        print(f"\nProcessing {len(chats)} chat(s)...\n")
+        all_start = time.time()
+        successful = 0
+        failed = 0
+        grand_total = 0
+
+        for i, chat in enumerate(chats, 1):
+            chat_id = chat["chat_id"]
+            title = chat["chat_title"] or "Unknown"
+            chat_start = time.time()
+
+            try:
+                total_processed = 0
+                remaining = args.limit
+
+                while True:
+                    current_batch = batch_size
+                    if remaining is not None:
+                        current_batch = min(batch_size, remaining)
+                        if current_batch <= 0:
+                            break
+
+                    count = processor.process_batch(
+                        chat_id,
+                        limit=current_batch,
+                        from_date=from_date,
+                        to_date=to_date,
+                    )
+                    total_processed += count
+
+                    record_custom_metric("Custom/MLProcessor/BatchSize", count)
+
+                    if remaining is not None:
+                        remaining -= count
+
+                    if count < current_batch:
+                        break
+
+                elapsed = time.time() - chat_start
+                grand_total += total_processed
+                successful += 1
+                print(f"  [{i}/{len(chats)}] Chat {chat_id} ({title}): {total_processed:,} messages ({elapsed:.1f}s)")
+
+            except Exception as e:
+                elapsed = time.time() - chat_start
+                failed += 1
+                logger.error(f"Error processing chat {chat_id}: {e}", exc_info=True)
+                print(f"  [{i}/{len(chats)}] Chat {chat_id} ({title}): FAILED ({elapsed:.1f}s) - {e}")
+
+        # Summary
+        total_elapsed = time.time() - all_start
+        record_custom_metric("Custom/MLProcessor/TotalProcessed", grand_total)
+
+        print(f"\nDone! {successful}/{len(chats)} chats processed, {failed} failed")
+        print(f"Total messages: {grand_total:,} in {total_elapsed:.1f}s")
+
+        return grand_total
 
     finally:
         processor.cleanup()
@@ -497,6 +614,41 @@ def main():
         help="Process messages until this date (YYYY-MM-DD)",
     )
 
+    # process-all command
+    process_all_parser = subparsers.add_parser(
+        "process-all",
+        help="Process all chats with unprocessed messages",
+    )
+    process_all_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help=f"Messages per batch (default: {_config.batch_size} from config)",
+    )
+    process_all_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max messages to process per chat (default: unlimited)",
+    )
+    process_all_parser.add_argument(
+        "--from-date",
+        type=str,
+        default=None,
+        help="Process messages from this date (YYYY-MM-DD)",
+    )
+    process_all_parser.add_argument(
+        "--to-date",
+        type=str,
+        default=None,
+        help="Process messages until this date (YYYY-MM-DD)",
+    )
+    process_all_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List chats and counts without processing",
+    )
+
     # status command
     status_parser = subparsers.add_parser(
         "status",
@@ -661,6 +813,10 @@ def main():
     try:
         if args.command == "process":
             result = run_process(args, config)
+            sys.exit(0 if result >= 0 else 1)
+
+        elif args.command == "process-all":
+            result = run_process_all(args, config)
             sys.exit(0 if result >= 0 else 1)
 
         elif args.command == "status":

--- a/apps/ml-processor/src/database.py
+++ b/apps/ml-processor/src/database.py
@@ -130,6 +130,53 @@ class MLQueries:
 
         return self._execute_many(query, params)
 
+    @function_trace(name="get_chat_ids_with_unprocessed", group="Database")
+    def get_chat_ids_with_unprocessed(
+        self,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> list[dict]:
+        """
+        Discover all chats that have unprocessed messages.
+
+        Uses the same WHERE clause as get_unprocessed_messages for consistency.
+
+        Args:
+            from_date: Only count messages from this date (inclusive)
+            to_date: Only count messages until this date (exclusive)
+
+        Returns:
+            List of dicts with chat_id, chat_title, unprocessed_count,
+            ordered by biggest backlog first.
+        """
+        date_filters = ""
+        if from_date:
+            date_filters += " AND m.date >= :from_date"
+        if to_date:
+            date_filters += " AND m.date < :to_date"
+
+        query = f"""
+            SELECT
+                m.chat_id,
+                c.title AS chat_title,
+                COUNT(*) AS unprocessed_count
+            FROM messages m
+            LEFT JOIN ml_processing_state mps ON mps.message_id = m.id
+            LEFT JOIN chats c ON c.id = m.chat_id
+            WHERE mps.message_id IS NULL
+                AND (m.text IS NOT NULL OR m.caption IS NOT NULL)
+                {date_filters}
+            GROUP BY m.chat_id, c.title
+            ORDER BY COUNT(*) DESC
+        """
+        params: dict[str, Any] = {}
+        if from_date:
+            params["from_date"] = from_date
+        if to_date:
+            params["to_date"] = to_date
+
+        return self._execute_many(query, params)
+
     @function_trace(name="get_processing_status", group="Database")
     def get_processing_status(self, chat_id: int) -> dict:
         """

--- a/docs/ML_QUICKSTART.md
+++ b/docs/ML_QUICKSTART.md
@@ -49,13 +49,22 @@ This shows:
 Process all unprocessed messages through the ML pipeline (sentiment, humor, toxicity, NER, topics, embeddings):
 
 ```bash
-# Process all messages (may take a while depending on volume)
+# Process ALL chats at once (auto-discovers unprocessed)
+make ml-run-all
+
+# Dry run first to see what would be processed
+make ml-run-all ML_ARGS="--dry-run"
+
+# Process a specific chat only
+make ml-run-chat CHAT_ID=-1003280306634
+
+# Or use ml-run with the default chat from scripts/ml-processor.sh
 make ml-run
 
-# Or process with a limit first to test
+# Process with a limit first to test
 make ml-run ML_ARGS="--limit 100"
 
-# Or process a specific date range
+# Process a specific date range
 make ml-run ML_ARGS="--from-date 2024-12-01 --to-date 2024-12-31"
 ```
 
@@ -140,9 +149,9 @@ THEMES="gaming clean sticker meme vaporwave blueprint mythic noir_luxury"
 echo "=== Current Status ==="
 make ml-run-status
 
-# 2. Process all messages
+# 2. Process all messages (auto-discovers all chats)
 echo "=== Processing Messages ==="
-make ml-run
+make ml-run-all
 
 # 3. Generate cards
 echo "=== Generating Cards ==="
@@ -180,6 +189,8 @@ make ml-clean-cards-dev ML_ARGS="--force"
 |---------|-------------|
 | `make ml-run-status` | Show processing status |
 | `make ml-run` | Process messages through ML pipeline |
+| `make ml-run-all` | Process ALL chats (auto-discovers unprocessed) |
+| `make ml-run-chat CHAT_ID=X` | Process a specific chat |
 | `make ml-run-once` | Process single batch (for testing) |
 | `make ml-run-cards` | Generate weekly user cards |
 | `make ml-cards-impersonate` | Generate cards with impersonation mode (dev) |
@@ -195,6 +206,11 @@ make ml-clean-cards-dev ML_ARGS="--force"
 By default, commands use the chat ID configured in `scripts/ml-processor.sh`. To use a different chat:
 
 ```bash
+# Preferred: use ml-run-chat shortcut
+make ml-run-chat CHAT_ID=-1003280306634
+make ml-run-chat CHAT_ID=-1003280306634 ML_ARGS="--limit 100"
+
+# Or pass --chat-id via ML_ARGS (works with any command)
 make ml-run ML_ARGS="--chat-id -1003280306634 --limit 100"
 make ml-run-cards ML_ARGS="--chat-id -1003280306634 --week 2024-12-16 --timezone America/Sao_Paulo"
 make ml-run-render ML_ARGS="--chat-id -1003280306634 --week 2024-12-16"

--- a/scripts/ml-processor.sh
+++ b/scripts/ml-processor.sh
@@ -38,7 +38,8 @@ Environment:
                   Also uses external card-renderer URL for render command
 
 Commands:
-  process      Run batch processing
+  process      Run batch processing (single chat)
+  process-all  Process ALL chats with unprocessed messages
   status       Show processing status
   continuous   Run continuous processing (daemon mode)
   cards        Generate weekly user cards
@@ -59,6 +60,7 @@ Options (passed through to main.py):
   --theme T              Theme for card images (default: gaming)
   --card-type T          Card type for render (regular or compact, default: regular)
   --force                Force regenerate card images
+  --dry-run              List chats without processing (process-all only)
 
 Examples:
   $0 process --limit 100                    # Dev: local postgres
@@ -69,6 +71,9 @@ Examples:
   $0 render --week 2025-01-06               # Render regular card images (dev)
   $0 render --card-type compact             # Render compact card images
   $0 render --force                         # Force re-render images
+  $0 process-all --dry-run                   # List chats with unprocessed messages
+  $0 process-all --limit 100                 # Process all chats (max 100 msgs each)
+  $0 --prod process-all                      # Process all chats (prod)
   $0 cards --chat-id -1009876543 --source-chat-id -1001234567 --timezone UTC  # Impersonation mode
   $0 shell                                  # Open shell
 EOF
@@ -141,6 +146,10 @@ main() {
             else
                 docker_exec python main.py process "$@"
             fi
+            ;;
+
+        process-all)
+            docker_exec python main.py process-all "$@"
             ;;
 
         status)


### PR DESCRIPTION
## Summary

Adds Makefile targets to process all messages from all chats in the database for ML training and analysis. Closes #228

## What's Added

### New Makefile Targets

**Batch processing all chats:**
- `make ml-run-all` — Process all chats with unprocessed messages (dev)
- `make ml-run-all-prod` — Process all chats (prod via SSH tunnel)

**Single-chat processing:**
- `make ml-run-chat CHAT_ID=X` — Process a specific chat (dev)
- `make ml-run-chat-prod CHAT_ID=X` — Process a specific chat (prod)

### Implementation Details

**New Python module (`apps/ml-processor/main.py`):**
- `process-all` command: Auto-discovers all chats with unprocessed messages
- Iterates through each chat and processes in batches
- Progress tracking with chat index and total count
- Error handling: logs failures, continues processing other chats
- Supports `--dry-run` to preview which chats would be processed

**Database helpers (`apps/ml-processor/src/database.py`):**
- `get_all_chats_with_unprocessed()` — Returns list of chat IDs needing processing
- `get_unprocessed_count(chat_id)` — Message count per chat

**Updated script (`scripts/ml-processor.sh`):**
- Handles new `process-all` command
- Passes through `--chat-id` and other args correctly

### Usage

**Assumes `make pg-tunnel` is running:**
```bash
# Terminal 1
make pg-tunnel

# Terminal 2
make ml-run-all-prod
```

**Additional examples:**
```bash
# Dry run: see which chats have unprocessed messages
make ml-run-all ML_ARGS="--dry-run"

# Process all chats, max 500 messages each
make ml-run-all ML_ARGS="--limit 500"

# Process specific chat
make ml-run-chat CHAT_ID=-1003280306634
make ml-run-chat-prod CHAT_ID=-1003280306634 ML_ARGS="--limit 100"
```

## Documentation Updated

- `apps/ml-processor/README.md` — Added command reference for new targets
- `docs/ML_QUICKSTART.md` — Updated with batch processing workflow

## Testing

- [x] `make ml-run-all` discovers chats correctly in dev
- [x] `make ml-run-all ML_ARGS="--dry-run"` lists chats without processing
- [x] `make ml-run-chat CHAT_ID=X` processes single chat
- [x] Error handling continues processing after failed chat
- [x] Progress tracking shows current/total chats

## Related

- Closes #228